### PR TITLE
feat: GitHub GraphQL client and boards list screen

### DIFF
--- a/src/app/(app)/(tabs)/_layout.tsx
+++ b/src/app/(app)/(tabs)/_layout.tsx
@@ -36,19 +36,16 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
+          title: 'Boards',
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="home-outline" size={size} color={color} />
+            <Ionicons name="albums-outline" size={size} color={color} />
           ),
         }}
       />
       <Tabs.Screen
         name="boards"
         options={{
-          title: 'Boards',
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="grid-outline" size={size} color={color} />
-          ),
+          href: null,
         }}
       />
       <Tabs.Screen

--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -1,51 +1,213 @@
-import { Text, StyleSheet, ScrollView, RefreshControl } from 'react-native'
-import { useState, useCallback, useMemo } from 'react'
+import {
+  Text,
+  StyleSheet,
+  FlatList,
+  View,
+  RefreshControl,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native'
+import { useCallback, useEffect, useMemo } from 'react'
+import Ionicons from '@expo/vector-icons/Ionicons'
 import { useCurrentUser } from '../../../hooks/use-current-user'
 import { Card } from '../../../components/ui/Card'
-import { fontSize, spacing } from '@trustdesign/shared/tokens'
+import { Badge } from '../../../components/ui/Badge'
+import { colors, fontSize, spacing } from '@trustdesign/shared/tokens'
 import { useTheme } from '../../../contexts/ThemeContext'
+import { useBoardsStore } from '../../../stores/boards-store'
+import { fetchUserBoards, type Board } from '../../../lib/github'
+import { fetchGithubPAT } from '../../../lib/github-pat'
 
-export default function HomeScreen() {
+function formatUpdatedAt(iso: string): string {
+  const date = new Date(iso)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7) return `${diffDays} days ago`
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+interface BoardCardProps {
+  board: Board
+  theme: ReturnType<typeof useTheme>['theme']
+}
+
+function BoardCard({ board, theme }: BoardCardProps) {
+  const s = useMemo(() => cardStyles(theme), [theme])
+  return (
+    <Card style={s.card}>
+      <View style={s.header}>
+        <Text style={s.title} numberOfLines={2}>
+          {board.title}
+        </Text>
+        <Badge
+          label={`${board.itemCount} item${board.itemCount !== 1 ? 's' : ''}`}
+          variant="secondary"
+        />
+      </View>
+      {board.shortDescription ? (
+        <Text style={s.description} numberOfLines={2}>
+          {board.shortDescription}
+        </Text>
+      ) : null}
+      <Text style={s.updatedAt}>Updated {formatUpdatedAt(board.updatedAt)}</Text>
+    </Card>
+  )
+}
+
+function cardStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    card: { marginBottom: spacing[3] },
+    header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: spacing[3] },
+    title: { flex: 1, fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, fontWeight: '600', color: theme.colors.foreground },
+    description: { marginTop: spacing[1], fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground },
+    updatedAt: { marginTop: spacing[2], fontSize: fontSize.xs.size, lineHeight: fontSize.xs.lineHeight, color: theme.colors.mutedForeground },
+  })
+}
+
+function SkeletonCard({ theme }: { theme: ReturnType<typeof useTheme>['theme'] }) {
+  const s = useMemo(() => skeletonStyles(theme), [theme])
+  return (
+    <Card style={s.card}>
+      <View style={s.titleRow}>
+        <View style={[s.shimmer, s.titleBlock]} />
+        <View style={[s.shimmer, s.badgeBlock]} />
+      </View>
+      <View style={[s.shimmer, s.descBlock]} />
+      <View style={[s.shimmer, s.dateBlock]} />
+    </Card>
+  )
+}
+
+function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    card: { marginBottom: spacing[3] },
+    titleRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing[3] },
+    shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
+    titleBlock: { flex: 1, height: 18 },
+    badgeBlock: { width: 64, height: 22, borderRadius: 99 },
+    descBlock: { marginTop: spacing[2], height: 14, width: '70%' },
+    dateBlock: { marginTop: spacing[2], height: 12, width: '30%' },
+  })
+}
+
+export default function BoardsScreen() {
   const user = useCurrentUser()
   const { theme } = useTheme()
-  const [refreshing, setRefreshing] = useState(false)
-  const onRefresh = useCallback(() => {
-    setRefreshing(true)
-    setTimeout(() => setRefreshing(false), 1000)
-  }, [])
+  const { boards, isLoading, error, setBoards, setLoading, setError } = useBoardsStore()
   const s = useMemo(() => styles(theme), [theme])
 
+  const loadBoards = useCallback(async () => {
+    if (!user?.id) return
+    setLoading(true)
+    setError(null)
+    try {
+      const pat = await fetchGithubPAT(user.id)
+      if (!pat) {
+        setError('Could not retrieve your GitHub token. Try relinking your account.')
+        return
+      }
+      const result = await fetchUserBoards(pat)
+      setBoards(result)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      if (message.includes('401') || message.toLowerCase().includes('expired')) {
+        setError('Your GitHub token has expired. Please relink your account.')
+      } else if (message.includes('403') || message.toLowerCase().includes('rate limit')) {
+        setError('GitHub API rate limit reached. Please wait a moment and try again.')
+      } else if (message.toLowerCase().includes('network') || message.toLowerCase().includes('fetch')) {
+        setError('Network error. Check your connection and try again.')
+      } else {
+        setError(`Failed to load boards: ${message}`)
+      }
+    }
+  }, [user?.id, setBoards, setLoading, setError])
+
+  useEffect(() => {
+    void loadBoards()
+  }, [loadBoards])
+
+  const onRefresh = useCallback(() => {
+    void loadBoards()
+  }, [loadBoards])
+
+  if (isLoading && boards.length === 0) {
+    return (
+      <FlatList
+        style={s.container}
+        contentContainerStyle={s.content}
+        data={[1, 2, 3, 4]}
+        keyExtractor={(item) => String(item)}
+        renderItem={() => <SkeletonCard theme={theme} />}
+        scrollEnabled={false}
+      />
+    )
+  }
+
+  if (error && boards.length === 0) {
+    return (
+      <View style={[s.container, s.centered]}>
+        <Ionicons name="alert-circle-outline" size={48} color={theme.colors.mutedForeground} />
+        <Text style={s.errorTitle}>Something went wrong</Text>
+        <Text style={s.errorBody}>{error}</Text>
+        <Pressable
+          style={s.retryButton}
+          onPress={onRefresh}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading boards"
+        >
+          {isLoading ? (
+            <ActivityIndicator color={colors.surface.background} size="small" />
+          ) : (
+            <Text style={s.retryLabel}>Try again</Text>
+          )}
+        </Pressable>
+      </View>
+    )
+  }
+
   return (
-    <ScrollView
+    <FlatList
       style={s.container}
-      contentContainerStyle={s.content}
+      contentContainerStyle={boards.length === 0 ? s.emptyContainer : s.content}
+      data={boards}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => <BoardCard board={item} theme={theme} />}
       refreshControl={
         <RefreshControl
-          refreshing={refreshing}
+          refreshing={isLoading}
           onRefresh={onRefresh}
           tintColor={theme.colors.primary}
         />
       }
-    >
-      <Text style={s.greeting}>Hello{user?.name ? `, ${user.name}` : ''}</Text>
-      <Text style={s.subtitle}>Your GitHub repositories, organised</Text>
-      <Card>
-        <Text style={s.cardTitle}>Connect GitHub</Text>
-        <Text style={s.cardBody}>
-          Link your GitHub account to start tracking issues and pull requests across your repos.
-        </Text>
-      </Card>
-    </ScrollView>
+      ListEmptyComponent={
+        <View style={s.emptyInner}>
+          <Ionicons name="albums-outline" size={48} color={theme.colors.mutedForeground} />
+          <Text style={s.emptyTitle}>No boards yet</Text>
+          <Text style={s.emptyBody}>
+            Create a GitHub Projects v2 board and it will appear here.
+          </Text>
+        </View>
+      }
+    />
   )
 }
 
 function styles(theme: ReturnType<typeof useTheme>['theme']) {
   return StyleSheet.create({
     container: { flex: 1, backgroundColor: theme.colors.muted },
-    content: { padding: spacing[6] },
-    greeting: { fontSize: fontSize['2xl'].size, lineHeight: fontSize['2xl'].lineHeight, fontWeight: '700', color: theme.colors.foreground, marginBottom: spacing[1] },
-    subtitle: { fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, color: theme.colors.mutedForeground, marginBottom: spacing[6] },
-    cardTitle: { fontSize: fontSize.lg.size, lineHeight: fontSize.lg.lineHeight, fontWeight: '600', color: theme.colors.foreground, marginBottom: spacing[2] },
-    cardBody: { fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, color: theme.colors.mutedForeground },
+    content: { padding: spacing[5] },
+    centered: { justifyContent: 'center', alignItems: 'center', padding: spacing[8] },
+    emptyContainer: { flex: 1, padding: spacing[5] },
+    emptyInner: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: spacing[3] },
+    emptyTitle: { fontSize: fontSize.lg.size, lineHeight: fontSize.lg.lineHeight, fontWeight: '600', color: theme.colors.foreground },
+    emptyBody: { fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground, textAlign: 'center' },
+    errorTitle: { marginTop: spacing[4], fontSize: fontSize.lg.size, lineHeight: fontSize.lg.lineHeight, fontWeight: '600', color: theme.colors.foreground },
+    errorBody: { marginTop: spacing[2], fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground, textAlign: 'center' },
+    retryButton: { marginTop: spacing[6], backgroundColor: theme.colors.primary, paddingVertical: spacing[3], paddingHorizontal: spacing[6], borderRadius: 12, minHeight: 44, justifyContent: 'center', alignItems: 'center' },
+    retryLabel: { fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, fontWeight: '600', color: colors.surface.background },
   })
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,6 +3,101 @@ const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql'
 
 const REQUIRED_SCOPES = ['project', 'read:org']
 
+export interface Board {
+  id: string
+  title: string
+  shortDescription: string | null
+  updatedAt: string
+  itemCount: number
+  url: string
+}
+
+interface ProjectV2Node {
+  id: string
+  title: string
+  shortDescription: string | null
+  updatedAt: string
+  items: { totalCount: number }
+  url: string
+}
+
+interface FetchBoardsResponse {
+  viewer: {
+    projectsV2: { nodes: ProjectV2Node[] }
+    organizations: {
+      nodes: { projectsV2: { nodes: ProjectV2Node[] } }[]
+    }
+  }
+}
+
+const FETCH_BOARDS_QUERY = `
+  query FetchBoards {
+    viewer {
+      projectsV2(first: 20) {
+        nodes {
+          id
+          title
+          shortDescription
+          updatedAt
+          items { totalCount }
+          url
+        }
+      }
+      organizations(first: 10) {
+        nodes {
+          projectsV2(first: 20) {
+            nodes {
+              id
+              title
+              shortDescription
+              updatedAt
+              items { totalCount }
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+function mapNode(node: ProjectV2Node): Board {
+  return {
+    id: node.id,
+    title: node.title,
+    shortDescription: node.shortDescription,
+    updatedAt: node.updatedAt,
+    itemCount: node.items.totalCount,
+    url: node.url,
+  }
+}
+
+/**
+ * Fetch all ProjectV2 boards the authenticated user has access to,
+ * including boards from their organisations.
+ */
+export async function fetchUserBoards(pat: string): Promise<Board[]> {
+  const data = await githubGraphQL<FetchBoardsResponse>(pat, FETCH_BOARDS_QUERY)
+
+  const userBoards = data.viewer.projectsV2.nodes.map(mapNode)
+
+  const orgBoards = data.viewer.organizations.nodes.flatMap((org) =>
+    org.projectsV2.nodes.map(mapNode)
+  )
+
+  // De-duplicate by id (a board may appear in both viewer and org results)
+  const seen = new Set<string>()
+  const all: Board[] = []
+  for (const board of [...userBoards, ...orgBoards]) {
+    if (!seen.has(board.id)) {
+      seen.add(board.id)
+      all.push(board)
+    }
+  }
+
+  return all.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+}
+
 interface ValidatePATResult {
   valid: boolean
   username?: string

--- a/src/stores/boards-store.ts
+++ b/src/stores/boards-store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+import type { Board } from '../lib/github'
+
+interface BoardsState {
+  boards: Board[]
+  isLoading: boolean
+  error: string | null
+  lastFetchedAt: number | null
+  setBoards: (boards: Board[]) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+}
+
+export const useBoardsStore = create<BoardsState>((set) => ({
+  boards: [],
+  isLoading: false,
+  error: null,
+  lastFetchedAt: null,
+  setBoards: (boards) => set({ boards, lastFetchedAt: Date.now(), error: null }),
+  setLoading: (loading) => set({ isLoading: loading }),
+  setError: (error) => set({ error, isLoading: false }),
+}))


### PR DESCRIPTION
## Summary
- GraphQL client for GitHub Projects v2 (viewer + org boards) via `fetchUserBoards()` in `src/lib/github.ts`
- Boards list screen replaces home tab placeholder — loading skeleton, empty state, error handling with retry
- Pull-to-refresh on boards list
- Zustand store (`boards-store.ts`) for board list state
- Home tab renamed Boards with `albums-outline` icon; old `boards.tsx` placeholder hidden via `href: null`

## Testing
1. Sign in, link PAT → lands on Boards tab showing GitHub project boards
2. Pull down to refresh → updates list
3. Remove network → error state with retry button appears
4. User with no projects → empty state with icon and message
5. Expired/invalid PAT → descriptive error message shown

Closes #3

---
This PR was created by Claude Code. Please review before merging.