### PR TITLE
feat: task list view for a board

### DIFF
--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import {
   ActivityIndicator,
 } from 'react-native'
 import { useCallback, useEffect, useMemo } from 'react'
+import { useRouter } from 'expo-router'
 import Ionicons from '@expo/vector-icons/Ionicons'
 import { useCurrentUser } from '../../../hooks/use-current-user'
 import { Card } from '../../../components/ui/Card'
@@ -33,28 +34,35 @@ function formatUpdatedAt(iso: string): string {
 interface BoardCardProps {
   board: Board
   theme: ReturnType<typeof useTheme>['theme']
+  onPress: () => void
 }
 
-function BoardCard({ board, theme }: BoardCardProps) {
+function BoardCard({ board, theme, onPress }: BoardCardProps) {
   const s = useMemo(() => cardStyles(theme), [theme])
   return (
-    <Card style={s.card}>
-      <View style={s.header}>
-        <Text style={s.title} numberOfLines={2}>
-          {board.title}
-        </Text>
-        <Badge
-          label={`${board.itemCount} item${board.itemCount !== 1 ? 's' : ''}`}
-          variant="secondary"
-        />
-      </View>
-      {board.shortDescription ? (
-        <Text style={s.description} numberOfLines={2}>
-          {board.shortDescription}
-        </Text>
-      ) : null}
-      <Text style={s.updatedAt}>Updated {formatUpdatedAt(board.updatedAt)}</Text>
-    </Card>
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Open board ${board.title}`}
+    >
+      <Card style={s.card}>
+        <View style={s.header}>
+          <Text style={s.title} numberOfLines={2}>
+            {board.title}
+          </Text>
+          <Badge
+            label={`${board.itemCount} item${board.itemCount !== 1 ? 's' : ''}`}
+            variant="secondary"
+          />
+        </View>
+        {board.shortDescription ? (
+          <Text style={s.description} numberOfLines={2}>
+            {board.shortDescription}
+          </Text>
+        ) : null}
+        <Text style={s.updatedAt}>Updated {formatUpdatedAt(board.updatedAt)}</Text>
+      </Card>
+    </Pressable>
   )
 }
 
@@ -97,6 +105,7 @@ function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
 export default function BoardsScreen() {
   const user = useCurrentUser()
   const { theme } = useTheme()
+  const router = useRouter()
   const { boards, isLoading, error, setBoards, setLoading, setError } = useBoardsStore()
   const s = useMemo(() => styles(theme), [theme])
 
@@ -175,7 +184,13 @@ export default function BoardsScreen() {
       contentContainerStyle={boards.length === 0 ? s.emptyContainer : s.content}
       data={boards}
       keyExtractor={(item) => item.id}
-      renderItem={({ item }) => <BoardCard board={item} theme={theme} />}
+      renderItem={({ item }) => (
+          <BoardCard
+            board={item}
+            theme={theme}
+            onPress={() => router.push(`/(app)/board/${item.id}`)}
+          />
+        )}
       refreshControl={
         <RefreshControl
           refreshing={isLoading}

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -16,6 +16,10 @@ export default function AppLayout() {
         name="settings"
         options={{ headerShown: true, title: 'Settings', presentation: 'card' }}
       />
+      <Stack.Screen
+        name="board"
+        options={{ headerShown: true, presentation: 'card' }}
+      />
     </Stack>
   )
 }

--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -1,0 +1,465 @@
+import {
+  View,
+  Text,
+  SectionList,
+  StyleSheet,
+  Pressable,
+  RefreshControl,
+  ActivityIndicator,
+} from 'react-native'
+import { useCallback, useEffect, useMemo } from 'react'
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import Ionicons from '@expo/vector-icons/Ionicons'
+import { colors, fontSize, spacing, borderRadius } from '@trustdesign/shared/tokens'
+import { useTheme } from '../../../contexts/ThemeContext'
+import { useCurrentUser } from '../../../hooks/use-current-user'
+import { fetchGithubPAT } from '../../../lib/github-pat'
+import { fetchBoardItems, groupTasksByStatus, type BoardColumn, type Task } from '../../../lib/github'
+import { useTasksStore } from '../../../stores/tasks-store'
+import { useBoardsStore } from '../../../stores/boards-store'
+import { Avatar } from '../../../components/ui/Avatar'
+import { Card } from '../../../components/ui/Card'
+
+// ---------------------------------------------------------------------------
+// Skeleton
+// ---------------------------------------------------------------------------
+
+function SkeletonTaskCard({ theme }: { theme: ReturnType<typeof useTheme>['theme'] }) {
+  const s = useMemo(() => skeletonStyles(theme), [theme])
+  return (
+    <Card style={s.card}>
+      <View style={s.titleRow}>
+        <View style={[s.shimmer, s.titleBlock]} />
+        <View style={[s.shimmer, s.numberBlock]} />
+      </View>
+      <View style={s.row}>
+        <View style={[s.shimmer, s.labelChip]} />
+        <View style={[s.shimmer, s.labelChip]} />
+      </View>
+    </Card>
+  )
+}
+
+function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    card: { marginBottom: spacing[2] },
+    titleRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing[3] },
+    row: { flexDirection: 'row', gap: spacing[2], marginTop: spacing[2] },
+    shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
+    titleBlock: { flex: 1, height: 16 },
+    numberBlock: { width: 48, height: 14 },
+    labelChip: { width: 60, height: 20, borderRadius: 99 },
+  })
+}
+
+function SkeletonSection({ theme }: { theme: ReturnType<typeof useTheme>['theme'] }) {
+  const s = useMemo(() => skeletonSectionStyles(theme), [theme])
+  return (
+    <View style={s.section}>
+      <View style={[s.shimmer, s.header]} />
+      <SkeletonTaskCard theme={theme} />
+      <SkeletonTaskCard theme={theme} />
+      <SkeletonTaskCard theme={theme} />
+    </View>
+  )
+}
+
+function skeletonSectionStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    section: { marginBottom: spacing[6] },
+    shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
+    header: { height: 20, width: '40%', marginBottom: spacing[3] },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Label chip
+// ---------------------------------------------------------------------------
+
+function LabelChip({ name, color: hexColor }: { name: string; color: string }) {
+  const bg = `#${hexColor}26`
+  const text = `#${hexColor}`
+  return (
+    <View style={[labelChipStyles.chip, { backgroundColor: bg }]}>
+      <Text style={[labelChipStyles.label, { color: text }]} numberOfLines={1}>
+        {name}
+      </Text>
+    </View>
+  )
+}
+
+const labelChipStyles = StyleSheet.create({
+  chip: {
+    borderRadius: 99,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontSize: fontSize.xs.size,
+    lineHeight: fontSize.xs.lineHeight,
+    fontWeight: '600',
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Task card
+// ---------------------------------------------------------------------------
+
+interface TaskCardProps {
+  task: Task
+  theme: ReturnType<typeof useTheme>['theme']
+  onPress: () => void
+}
+
+function TaskCard({ task, theme, onPress }: TaskCardProps) {
+  const s = useMemo(() => taskCardStyles(theme), [theme])
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={task.title}
+    >
+      <Card style={s.card}>
+        <View style={s.topRow}>
+          <Text style={s.title} numberOfLines={2}>
+            {task.title}
+          </Text>
+          {task.issueNumber != null && (
+            <Text style={s.issueNumber}>#{task.issueNumber}</Text>
+          )}
+        </View>
+
+        {task.labels.length > 0 && (
+          <View style={s.labels}>
+            {task.labels.map((label) => (
+              <LabelChip key={label.name} name={label.name} color={label.color} />
+            ))}
+          </View>
+        )}
+
+        {task.assignees.length > 0 && (
+          <View style={s.assignees}>
+            {task.assignees.map((assignee, index) => (
+              <Avatar
+                key={assignee.login}
+                uri={assignee.avatarUrl}
+                name={assignee.login}
+                size="sm"
+                style={[s.avatar, index > 0 && s.avatarOverlap]}
+              />
+            ))}
+          </View>
+        )}
+      </Card>
+    </Pressable>
+  )
+}
+
+function taskCardStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    card: { marginBottom: spacing[2] },
+    topRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      gap: spacing[2],
+    },
+    title: {
+      flex: 1,
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    issueNumber: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      color: theme.colors.mutedForeground,
+      paddingTop: 2,
+    },
+    labels: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing[1],
+      marginTop: spacing[2],
+    },
+    assignees: {
+      flexDirection: 'row',
+      marginTop: spacing[2],
+    },
+    avatar: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+    },
+    avatarOverlap: {
+      marginLeft: -8,
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+function SectionHeader({
+  title,
+  count,
+  theme,
+}: {
+  title: string
+  count: number
+  theme: ReturnType<typeof useTheme>['theme']
+}) {
+  const s = useMemo(() => sectionHeaderStyles(theme), [theme])
+  return (
+    <View style={s.container}>
+      <Text style={s.title}>{title}</Text>
+      <Text style={s.count}>{count}</Text>
+    </View>
+  )
+}
+
+function sectionHeaderStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing[2],
+      paddingVertical: spacing[2],
+      paddingHorizontal: spacing[5],
+      backgroundColor: theme.colors.muted,
+    },
+    title: {
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.mutedForeground,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    count: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      color: theme.colors.mutedForeground,
+      backgroundColor: theme.colors.card,
+      paddingHorizontal: spacing[2],
+      paddingVertical: 1,
+      borderRadius: 99,
+      overflow: 'hidden',
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+export default function BoardScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { theme } = useTheme()
+  const user = useCurrentUser()
+  const router = useRouter()
+  const navigation = useNavigation()
+
+  const { tasksByBoard, isLoading, error, setTasks, setLoading, setError } = useTasksStore()
+  const boards = useBoardsStore((state) => state.boards)
+
+  const tasks = id ? (tasksByBoard[id] ?? null) : null
+  const board = id ? boards.find((b) => b.id === id) : undefined
+
+  // Set the header title to the board name
+  useEffect(() => {
+    if (board?.title) {
+      navigation.setOptions({ title: board.title })
+    }
+  }, [board?.title, navigation])
+
+  const loadTasks = useCallback(async () => {
+    if (!id || !user?.id) return
+    setLoading(true)
+    setError(null)
+    try {
+      const pat = await fetchGithubPAT(user.id)
+      if (!pat) {
+        setError('Could not retrieve your GitHub token. Try relinking your account.')
+        return
+      }
+      const result = await fetchBoardItems(pat, id)
+      setTasks(id, result)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      if (message.includes('401') || message.toLowerCase().includes('expired')) {
+        setError('Your GitHub token has expired. Please relink your account.')
+      } else if (message.includes('403') || message.toLowerCase().includes('rate limit')) {
+        setError('GitHub API rate limit reached. Please wait a moment and try again.')
+      } else if (message.toLowerCase().includes('network') || message.toLowerCase().includes('fetch')) {
+        setError('Network error. Check your connection and try again.')
+      } else {
+        setError(`Failed to load tasks: ${message}`)
+      }
+    }
+  }, [id, user?.id, setTasks, setLoading, setError])
+
+  useEffect(() => {
+    if (tasks === null) {
+      void loadTasks()
+    }
+  }, [tasks, loadTasks])
+
+  const onRefresh = useCallback(() => {
+    void loadTasks()
+  }, [loadTasks])
+
+  const { theme: t } = useTheme()
+  const s = useMemo(() => styles(t), [t])
+
+  const columns: BoardColumn[] = useMemo(
+    () => (tasks ? groupTasksByStatus(tasks) : []),
+    [tasks]
+  )
+
+  const sections = useMemo(
+    () => columns.map((col) => ({ title: col.name, data: col.tasks, count: col.tasks.length })),
+    [columns]
+  )
+
+  // Loading skeleton
+  if (isLoading && tasks === null) {
+    return (
+      <View style={s.container}>
+        <SkeletonSection theme={theme} />
+        <SkeletonSection theme={theme} />
+        <SkeletonSection theme={theme} />
+      </View>
+    )
+  }
+
+  // Error state
+  if (error && tasks === null) {
+    return (
+      <View style={[s.container, s.centered]}>
+        <Ionicons name="alert-circle-outline" size={48} color={theme.colors.mutedForeground} />
+        <Text style={s.errorTitle}>Something went wrong</Text>
+        <Text style={s.errorBody}>{error}</Text>
+        <Pressable
+          style={s.retryButton}
+          onPress={onRefresh}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading tasks"
+        >
+          {isLoading ? (
+            <ActivityIndicator color={colors.surface.background} size="small" />
+          ) : (
+            <Text style={s.retryLabel}>Try again</Text>
+          )}
+        </Pressable>
+      </View>
+    )
+  }
+
+  // Empty state
+  if (tasks !== null && tasks.length === 0) {
+    return (
+      <View style={[s.container, s.centered]}>
+        <Ionicons name="checkmark-circle-outline" size={48} color={theme.colors.mutedForeground} />
+        <Text style={s.emptyTitle}>No items yet</Text>
+        <Text style={s.emptyBody}>
+          Add issues or draft items to this board in GitHub and they'll appear here.
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <SectionList
+      style={s.container}
+      contentContainerStyle={s.content}
+      sections={sections}
+      keyExtractor={(item) => item.id}
+      renderSectionHeader={({ section }) => (
+        <SectionHeader title={section.title} count={section.count} theme={theme} />
+      )}
+      renderItem={({ item }) => (
+        <View style={s.taskPadding}>
+          <TaskCard
+            task={item}
+            theme={theme}
+            onPress={() =>
+              router.push({
+                pathname: '/(app)/task/[id]',
+                params: { id: item.id, boardId: id },
+              })
+            }
+          />
+        </View>
+      )}
+      refreshControl={
+        <RefreshControl
+          refreshing={isLoading}
+          onRefresh={onRefresh}
+          tintColor={theme.colors.primary}
+        />
+      }
+      stickySectionHeadersEnabled
+    />
+  )
+}
+
+function styles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.muted },
+    content: { paddingBottom: spacing[8] },
+    taskPadding: { paddingHorizontal: spacing[5], paddingTop: spacing[2] },
+    centered: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: spacing[8],
+    },
+    emptyTitle: {
+      marginTop: spacing[4],
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    emptyBody: {
+      marginTop: spacing[2],
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
+    },
+    errorTitle: {
+      marginTop: spacing[4],
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    errorBody: {
+      marginTop: spacing[2],
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
+    },
+    retryButton: {
+      marginTop: spacing[6],
+      backgroundColor: theme.colors.primary,
+      paddingVertical: spacing[3],
+      paddingHorizontal: spacing[6],
+      borderRadius: borderRadius['xl'],
+      minHeight: 44,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    retryLabel: {
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      fontWeight: '600',
+      color: colors.surface.background,
+    },
+  })
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -147,6 +147,249 @@ export async function validatePAT(pat: string): Promise<ValidatePATResult> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Board items (task list)
+// ---------------------------------------------------------------------------
+
+export interface TaskAssignee {
+  login: string
+  avatarUrl: string
+}
+
+export interface TaskLabel {
+  name: string
+  color: string
+}
+
+export interface Task {
+  id: string
+  title: string
+  /** Resolved status name from the Status single-select field, or null */
+  status: string | null
+  statusOptionId: string | null
+  assignees: TaskAssignee[]
+  labels: TaskLabel[]
+  /** Null for DraftIssues */
+  issueNumber: number | null
+  issueState: 'OPEN' | 'CLOSED' | null
+  isDraft: boolean
+}
+
+export interface BoardColumn {
+  name: string
+  tasks: Task[]
+}
+
+/** Status field option as returned by the GraphQL API */
+interface StatusOption {
+  id: string
+  name: string
+  color: string
+}
+
+interface FieldNode {
+  id?: string
+  name?: string
+  options?: StatusOption[]
+}
+
+interface FieldValueNode {
+  field?: { name?: string }
+  name?: string
+  optionId?: string
+}
+
+type ItemContent =
+  | {
+      __typename: 'Issue'
+      title: string
+      number: number
+      state: 'OPEN' | 'CLOSED'
+      url: string
+      assignees: { nodes: { login: string; avatarUrl: string }[] }
+      labels: { nodes: { name: string; color: string }[] }
+    }
+  | { __typename: 'DraftIssue'; title: string }
+  | null
+
+interface ItemNode {
+  id: string
+  fieldValues: { nodes: FieldValueNode[] }
+  content: ItemContent
+}
+
+interface FetchBoardItemsResponse {
+  node: {
+    title: string
+    fields: { nodes: FieldNode[] }
+    items: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+      nodes: ItemNode[]
+    }
+  }
+}
+
+const FETCH_BOARD_ITEMS_QUERY = `
+  query FetchBoardItems($projectId: ID!, $cursor: String) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        title
+        fields(first: 20) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              options { id name color }
+            }
+          }
+        }
+        items(first: 50, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            fieldValues(first: 20) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  field { ... on ProjectV2SingleSelectField { name } }
+                  name
+                  optionId
+                }
+              }
+            }
+            content {
+              ... on Issue {
+                __typename
+                title
+                number
+                state
+                url
+                assignees(first: 5) { nodes { login avatarUrl } }
+                labels(first: 5) { nodes { name color } }
+              }
+              ... on DraftIssue {
+                __typename
+                title
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+function mapItem(item: ItemNode): Task {
+  const statusFieldValue = item.fieldValues.nodes.find(
+    (fv) => fv.field?.name?.toLowerCase() === 'status' && fv.name != null
+  )
+
+  const content = item.content
+
+  if (!content) {
+    return {
+      id: item.id,
+      title: '(No title)',
+      status: statusFieldValue?.name ?? null,
+      statusOptionId: statusFieldValue?.optionId ?? null,
+      assignees: [],
+      labels: [],
+      issueNumber: null,
+      issueState: null,
+      isDraft: true,
+    }
+  }
+
+  if (content.__typename === 'Issue') {
+    return {
+      id: item.id,
+      title: content.title,
+      status: statusFieldValue?.name ?? null,
+      statusOptionId: statusFieldValue?.optionId ?? null,
+      assignees: content.assignees.nodes,
+      labels: content.labels.nodes,
+      issueNumber: content.number,
+      issueState: content.state,
+      isDraft: false,
+    }
+  }
+
+  // DraftIssue
+  return {
+    id: item.id,
+    title: content.title,
+    status: statusFieldValue?.name ?? null,
+    statusOptionId: statusFieldValue?.optionId ?? null,
+    assignees: [],
+    labels: [],
+    issueNumber: null,
+    issueState: null,
+    isDraft: true,
+  }
+}
+
+/**
+ * Fetch all items from a ProjectV2 board using cursor-based pagination.
+ * Resolves status field option names so each task has a human-readable status.
+ */
+export async function fetchBoardItems(pat: string, projectId: string): Promise<Task[]> {
+  const tasks: Task[] = []
+  let cursor: string | null = null
+  let hasNextPage = true
+
+  while (hasNextPage) {
+    const variables: Record<string, unknown> = { projectId }
+    if (cursor) variables.cursor = cursor
+
+    const data = await githubGraphQL<FetchBoardItemsResponse>(
+      pat,
+      FETCH_BOARD_ITEMS_QUERY,
+      variables
+    )
+
+    const page = data.node.items
+    for (const item of page.nodes) {
+      tasks.push(mapItem(item))
+    }
+
+    hasNextPage = page.pageInfo.hasNextPage
+    cursor = page.pageInfo.endCursor
+  }
+
+  return tasks
+}
+
+/**
+ * Group a flat list of tasks into columns ordered by first-seen status.
+ * Tasks with no status are collected in a trailing "No Status" column.
+ */
+export function groupTasksByStatus(tasks: Task[]): BoardColumn[] {
+  const columnMap = new Map<string, Task[]>()
+
+  for (const task of tasks) {
+    const key = task.status ?? 'No Status'
+    if (!columnMap.has(key)) {
+      columnMap.set(key, [])
+    }
+    columnMap.get(key)!.push(task)
+  }
+
+  const columns: BoardColumn[] = []
+  for (const [name, columnTasks] of columnMap) {
+    if (name !== 'No Status') {
+      columns.push({ name, tasks: columnTasks })
+    }
+  }
+
+  const noStatus = columnMap.get('No Status')
+  if (noStatus && noStatus.length > 0) {
+    columns.push({ name: 'No Status', tasks: noStatus })
+  }
+
+  return columns
+}
+
+// ---------------------------------------------------------------------------
+
 /** Execute a GraphQL query against the GitHub API using a PAT. */
 export async function githubGraphQL<T>(
   pat: string,

--- a/src/stores/tasks-store.ts
+++ b/src/stores/tasks-store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import type { Task } from '../lib/github'
+
+interface TasksState {
+  /** Map of boardId → tasks array */
+  tasksByBoard: Record<string, Task[]>
+  isLoading: boolean
+  error: string | null
+  setTasks: (boardId: string, tasks: Task[]) => void
+  setLoading: (loading: boolean) => void
+  setError: (error: string | null) => void
+  clearBoard: (boardId: string) => void
+}
+
+export const useTasksStore = create<TasksState>((set) => ({
+  tasksByBoard: {},
+  isLoading: false,
+  error: null,
+  setTasks: (boardId, tasks) =>
+    set((state) => ({
+      tasksByBoard: { ...state.tasksByBoard, [boardId]: tasks },
+      error: null,
+    })),
+  setLoading: (loading) => set({ isLoading: loading }),
+  setError: (error) => set({ error, isLoading: false }),
+  clearBoard: (boardId) =>
+    set((state) => {
+      const next = { ...state.tasksByBoard }
+      delete next[boardId]
+      return { tasksByBoard: next }
+    }),
+}))


### PR DESCRIPTION
## Summary

- Adds `fetchBoardItems()` to `lib/github.ts` — paginated ProjectV2 items query with cursor-based pagination (handles 100+ items)
- Adds `groupTasksByStatus()` helper to group tasks into `BoardColumn[]`
- Adds `Task`, `TaskAssignee`, `TaskLabel`, `BoardColumn` types
- Adds `src/stores/tasks-store.ts` — Zustand store keyed by boardId
- Adds `src/app/(app)/board/[id].tsx` — SectionList view grouped by status column
- Registers `board` Stack.Screen in `(app)/_layout.tsx`
- Adds tap-to-navigate on `BoardCard` in the boards list

## Acceptance criteria

- [x] Task list screen at `app/(app)/board/[id].tsx`
- [x] Fetch all items from a ProjectV2 via GraphQL (with pagination)
- [x] Group tasks by status field (column)
- [x] Each task row shows: title, assignees, labels, status (column header)
- [x] Tap a task to navigate to task detail
- [x] Pull-to-refresh
- [x] Loading skeleton (3 section headers + 3 rows each)
- [x] Empty state for boards with no items
- [x] Handle boards with 100+ items (cursor-based pagination)
- [x] Handle both DraftIssues and Issues

## Test plan

- [ ] Open the app and tap a board from the boards list
- [ ] Verify tasks are grouped into labelled sections by status
- [ ] Verify task cards show title, issue number, label chips, and assignee avatars
- [ ] Pull-to-refresh and confirm tasks reload
- [ ] Test with a board that has no items — confirm empty state
- [ ] Test with a board that has > 100 items — confirm all tasks load via pagination
- [ ] Tap a task card — confirm navigation to task detail route

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)