### PR TITLE
feat: task detail view (read-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "starter-native",
+  "name": "gitlist",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "starter-native",
+      "name": "gitlist",
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
@@ -28,6 +28,7 @@
         "react-dom": "^19.2.0",
         "react-native": "0.83.4",
         "react-native-gesture-handler": "~2.30.0",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
@@ -6328,6 +6329,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001782",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
@@ -6695,6 +6705,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssom": {
@@ -12402,6 +12432,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -12573,6 +12612,37 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -12588,6 +12658,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -13563,7 +13639,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14218,6 +14293,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -14338,7 +14419,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -14350,7 +14430,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -14570,6 +14649,15 @@
         }
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.1.tgz",
@@ -14593,6 +14681,22 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
       }
     },
     "node_modules/react-native-reanimated": {
@@ -16912,6 +17016,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^19.2.0",
     "react-native": "0.83.4",
     "react-native-gesture-handler": "~2.30.0",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -20,6 +20,10 @@ export default function AppLayout() {
         name="board"
         options={{ headerShown: true, presentation: 'card' }}
       />
+      <Stack.Screen
+        name="task"
+        options={{ headerShown: true, presentation: 'card' }}
+      />
     </Stack>
   )
 }

--- a/src/app/(app)/task/[id].tsx
+++ b/src/app/(app)/task/[id].tsx
@@ -1,0 +1,539 @@
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+  Linking,
+} from 'react-native'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
+import Markdown from 'react-native-markdown-display'
+import Ionicons from '@expo/vector-icons/Ionicons'
+import { colors, fontSize, spacing, borderRadius } from '@trustdesign/shared/tokens'
+import { useTheme } from '../../../contexts/ThemeContext'
+import { useCurrentUser } from '../../../hooks/use-current-user'
+import { fetchGithubPAT } from '../../../lib/github-pat'
+import { fetchTaskDetail, type TaskDetail, type TaskAssignee, type TaskLabel } from '../../../lib/github'
+import { useTasksStore } from '../../../stores/tasks-store'
+import { Avatar } from '../../../components/ui/Avatar'
+
+// ---------------------------------------------------------------------------
+// Label chip
+// ---------------------------------------------------------------------------
+
+function LabelChip({ name, color: hexColor }: { name: string; color: string }) {
+  const bg = `#${hexColor}26`
+  const text = `#${hexColor}`
+  return (
+    <View style={[labelChipStyles.chip, { backgroundColor: bg }]}>
+      <Text style={[labelChipStyles.label, { color: text }]} numberOfLines={1}>
+        {name}
+      </Text>
+    </View>
+  )
+}
+
+const labelChipStyles = StyleSheet.create({
+  chip: {
+    borderRadius: 99,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontSize: fontSize.xs.size,
+    lineHeight: fontSize.xs.lineHeight,
+    fontWeight: '600',
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <View style={statusBadgeStyles.badge}>
+      <Text style={statusBadgeStyles.label}>{status}</Text>
+    </View>
+  )
+}
+
+const statusBadgeStyles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-start',
+    borderRadius: 99,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1],
+    backgroundColor: colors.brand.primary + '26',
+  },
+  label: {
+    fontSize: fontSize.xs.size,
+    lineHeight: fontSize.xs.lineHeight,
+    fontWeight: '600',
+    color: colors.brand.primary,
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Assignees row
+// ---------------------------------------------------------------------------
+
+function AssigneesRow({ assignees }: { assignees: TaskAssignee[] }) {
+  return (
+    <View style={assigneesRowStyles.row}>
+      {assignees.map((assignee, index) => (
+        <View
+          key={assignee.login}
+          style={[assigneesRowStyles.avatarWrap, index > 0 && assigneesRowStyles.overlap]}
+        >
+          <Avatar uri={assignee.avatarUrl} name={assignee.login} size="sm" />
+        </View>
+      ))}
+      <Text style={assigneesRowStyles.logins}>
+        {assignees.map((a) => a.login).join(', ')}
+      </Text>
+    </View>
+  )
+}
+
+const assigneesRowStyles = StyleSheet.create({
+  row: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: spacing[2] },
+  avatarWrap: {},
+  overlap: { marginLeft: -8 },
+  logins: {
+    fontSize: fontSize.sm.size,
+    lineHeight: fontSize.sm.lineHeight,
+    color: colors.neutral[600],
+    marginLeft: spacing[1],
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Metadata row (priority / due date)
+// ---------------------------------------------------------------------------
+
+interface MetaItemProps {
+  icon: keyof typeof Ionicons.glyphMap
+  label: string
+  value: string
+  theme: ReturnType<typeof useTheme>['theme']
+}
+
+function MetaItem({ icon, label, value, theme }: MetaItemProps) {
+  const s = useMemo(() => metaItemStyles(theme), [theme])
+  return (
+    <View style={s.container}>
+      <Ionicons name={icon} size={14} color={theme.colors.mutedForeground} />
+      <Text style={s.label}>{label}</Text>
+      <Text style={s.value}>{value}</Text>
+    </View>
+  )
+}
+
+function metaItemStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    container: { flexDirection: 'row', alignItems: 'center', gap: spacing[1] },
+    label: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      color: theme.colors.mutedForeground,
+    },
+    value: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+export default function TaskDetailScreen() {
+  const { id, boardId } = useLocalSearchParams<{ id: string; boardId?: string }>()
+  const { theme } = useTheme()
+  const user = useCurrentUser()
+  const router = useRouter()
+  const navigation = useNavigation()
+
+  const tasksByBoard = useTasksStore((state) => state.tasksByBoard)
+
+  const [detail, setDetail] = useState<TaskDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Try to bootstrap from store first (avoids a network call if board was already loaded)
+  const cachedTask = useMemo(() => {
+    if (!id || !boardId) return null
+    return tasksByBoard[boardId]?.find((t) => t.id === id) ?? null
+  }, [id, boardId, tasksByBoard])
+
+  const loadDetail = useCallback(async () => {
+    if (!id || !user?.id) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const pat = await fetchGithubPAT(user.id)
+      if (!pat) {
+        setError('Could not retrieve your GitHub token. Try relinking your account.')
+        return
+      }
+      const result = await fetchTaskDetail(pat, id)
+      setDetail(result)
+      navigation.setOptions({ title: result.title })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      if (message.includes('401') || message.toLowerCase().includes('expired')) {
+        setError('Your GitHub token has expired. Please relink your account.')
+      } else if (message.toLowerCase().includes('not found')) {
+        setError('This task could not be found.')
+      } else {
+        setError(`Failed to load task: ${message}`)
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [id, user?.id, navigation])
+
+  useEffect(() => {
+    // Set initial title from store cache while we fetch full detail
+    if (cachedTask) {
+      navigation.setOptions({ title: cachedTask.title })
+    }
+    void loadDetail()
+  }, [cachedTask, loadDetail, navigation])
+
+  const s = useMemo(() => styles(theme), [theme])
+  const markdownStyles = useMemo(() => buildMarkdownStyles(theme), [theme])
+
+  if (isLoading && !detail) {
+    return (
+      <View style={[s.container, s.centered]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    )
+  }
+
+  if (error && !detail) {
+    return (
+      <View style={[s.container, s.centered]}>
+        <Ionicons name="alert-circle-outline" size={48} color={theme.colors.mutedForeground} />
+        <Text style={s.errorTitle}>Something went wrong</Text>
+        <Text style={s.errorBody}>{error}</Text>
+        <Pressable
+          style={s.actionButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Text style={s.actionButtonLabel}>Go back</Text>
+        </Pressable>
+      </View>
+    )
+  }
+
+  if (!detail) return null
+
+  const formattedDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    } catch {
+      return iso
+    }
+  }
+
+  return (
+    <ScrollView
+      style={s.container}
+      contentContainerStyle={s.content}
+    >
+      {/* Title */}
+      <Text style={s.title}>{detail.title}</Text>
+
+      {/* Status + draft badge */}
+      <View style={s.badgeRow}>
+        {detail.status != null && <StatusBadge status={detail.status} />}
+        {detail.isDraft && (
+          <View style={s.draftBadge}>
+            <Text style={s.draftLabel}>Draft</Text>
+          </View>
+        )}
+      </View>
+
+      {/* Labels */}
+      {detail.labels.length > 0 && (
+        <View style={s.labelsRow}>
+          {detail.labels.map((label: TaskLabel) => (
+            <LabelChip key={label.name} name={label.name} color={label.color} />
+          ))}
+        </View>
+      )}
+
+      {/* Assignees */}
+      {detail.assignees.length > 0 && (
+        <View style={s.section}>
+          <Text style={s.sectionLabel}>Assignees</Text>
+          <AssigneesRow assignees={detail.assignees} />
+        </View>
+      )}
+
+      {/* Issue link */}
+      {!detail.isDraft && detail.issueUrl != null && (
+        <View style={s.section}>
+          <Text style={s.sectionLabel}>Linked issue</Text>
+          <Pressable
+            onPress={() => {
+              if (detail.issueUrl) {
+                void Linking.openURL(detail.issueUrl)
+              }
+            }}
+            accessibilityRole="link"
+            accessibilityLabel={`Open issue #${detail.issueNumber ?? ''} on GitHub`}
+            style={s.issueLink}
+          >
+            <Ionicons name="open-outline" size={14} color={theme.colors.primary} />
+            <Text style={s.issueLinkText}>
+              #{detail.issueNumber} · {detail.issueState ?? 'OPEN'}
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Metadata grid (priority + due date) */}
+      {(detail.priority != null || detail.dueDate != null) && (
+        <View style={s.metaGrid}>
+          {detail.priority != null && (
+            <MetaItem
+              icon="flag-outline"
+              label="Priority"
+              value={detail.priority}
+              theme={theme}
+            />
+          )}
+          {detail.dueDate != null && (
+            <MetaItem
+              icon="calendar-outline"
+              label="Due"
+              value={formattedDate(detail.dueDate)}
+              theme={theme}
+            />
+          )}
+        </View>
+      )}
+
+      {/* Dates */}
+      <View style={s.metaGrid}>
+        <MetaItem
+          icon="time-outline"
+          label="Created"
+          value={formattedDate(detail.createdAt)}
+          theme={theme}
+        />
+        <MetaItem
+          icon="pencil-outline"
+          label="Updated"
+          value={formattedDate(detail.updatedAt)}
+          theme={theme}
+        />
+      </View>
+
+      {/* Body (markdown) */}
+      {detail.body != null && detail.body.trim().length > 0 && (
+        <View style={s.bodySection}>
+          <Text style={s.sectionLabel}>Description</Text>
+          <Markdown style={markdownStyles}>{detail.body}</Markdown>
+        </View>
+      )}
+    </ScrollView>
+  )
+}
+
+function styles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    content: {
+      padding: spacing[5],
+      paddingBottom: spacing[10],
+    },
+    centered: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: spacing[8],
+    },
+    title: {
+      fontSize: fontSize['2xl'].size,
+      lineHeight: fontSize['2xl'].lineHeight,
+      fontWeight: '700',
+      color: theme.colors.foreground,
+      marginBottom: spacing[3],
+    },
+    badgeRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing[2],
+      marginBottom: spacing[3],
+    },
+    draftBadge: {
+      alignSelf: 'flex-start',
+      borderRadius: 99,
+      paddingHorizontal: spacing[3],
+      paddingVertical: spacing[1],
+      backgroundColor: theme.colors.muted,
+    },
+    draftLabel: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.mutedForeground,
+    },
+    labelsRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing[2],
+      marginBottom: spacing[4],
+    },
+    section: {
+      marginBottom: spacing[4],
+      gap: spacing[2],
+    },
+    sectionLabel: {
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.mutedForeground,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      marginBottom: spacing[1],
+    },
+    issueLink: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing[1],
+    },
+    issueLinkText: {
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.primary,
+      fontWeight: '600',
+    },
+    metaGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing[4],
+      marginBottom: spacing[4],
+    },
+    bodySection: {
+      marginTop: spacing[2],
+    },
+    errorTitle: {
+      marginTop: spacing[4],
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    errorBody: {
+      marginTop: spacing[2],
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
+    },
+    actionButton: {
+      marginTop: spacing[6],
+      backgroundColor: theme.colors.primary,
+      paddingVertical: spacing[3],
+      paddingHorizontal: spacing[6],
+      borderRadius: borderRadius['xl'],
+      minHeight: 44,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    actionButtonLabel: {
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      fontWeight: '600',
+      color: colors.surface.background,
+    },
+  })
+}
+
+function buildMarkdownStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    body: {
+      color: theme.colors.foreground,
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+    },
+    heading1: {
+      fontSize: fontSize['2xl'].size,
+      lineHeight: fontSize['2xl'].lineHeight,
+      fontWeight: '700',
+      color: theme.colors.foreground,
+      marginTop: spacing[4],
+      marginBottom: spacing[2],
+    },
+    heading2: {
+      fontSize: fontSize.xl.size,
+      lineHeight: fontSize.xl.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.foreground,
+      marginTop: spacing[4],
+      marginBottom: spacing[2],
+    },
+    heading3: {
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+      marginTop: spacing[3],
+      marginBottom: spacing[1],
+    },
+    code_inline: {
+      backgroundColor: theme.colors.muted,
+      color: theme.colors.foreground,
+      borderRadius: 4,
+      paddingHorizontal: spacing[1],
+      fontFamily: 'monospace',
+    } as const,
+    fence: {
+      backgroundColor: theme.colors.muted,
+      borderRadius: 6,
+      padding: spacing[3],
+      marginVertical: spacing[2],
+    },
+    code_block: {
+      backgroundColor: theme.colors.muted,
+      borderRadius: 6,
+      padding: spacing[3],
+      fontFamily: 'monospace',
+      color: theme.colors.foreground,
+    },
+    blockquote: {
+      borderLeftWidth: 4,
+      borderLeftColor: theme.colors.primary,
+      paddingLeft: spacing[3],
+      marginVertical: spacing[2],
+      opacity: 0.8,
+    },
+    bullet_list: { marginVertical: spacing[2] },
+    ordered_list: { marginVertical: spacing[2] },
+    list_item: { marginBottom: spacing[1] },
+    paragraph: { marginBottom: spacing[3] },
+    link: { color: theme.colors.primary },
+    strong: { fontWeight: '700' },
+    em: { fontStyle: 'italic' },
+  })
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -389,6 +389,217 @@ export function groupTasksByStatus(tasks: Task[]): BoardColumn[] {
 }
 
 // ---------------------------------------------------------------------------
+// Task detail
+// ---------------------------------------------------------------------------
+
+export interface TaskDetail {
+  id: string
+  title: string
+  body: string | null
+  isDraft: boolean
+  issueNumber: number | null
+  issueState: 'OPEN' | 'CLOSED' | null
+  issueUrl: string | null
+  author: string | null
+  createdAt: string
+  updatedAt: string
+  status: string | null
+  /** From "Priority" single-select field if present */
+  priority: string | null
+  /** From "Due Date" date field if present */
+  dueDate: string | null
+  assignees: TaskAssignee[]
+  labels: TaskLabel[]
+}
+
+interface TaskDetailFieldValue {
+  field?: { name?: string }
+  name?: string
+  optionId?: string
+  date?: string
+  text?: string
+  number?: number
+}
+
+type TaskDetailContent =
+  | {
+      __typename: 'Issue'
+      title: string
+      number: number
+      state: 'OPEN' | 'CLOSED'
+      url: string
+      body: string | null
+      createdAt: string
+      updatedAt: string
+      author: { login: string } | null
+      assignees: { nodes: { login: string; avatarUrl: string }[] }
+      labels: { nodes: { name: string; color: string }[] }
+    }
+  | {
+      __typename: 'DraftIssue'
+      title: string
+      body: string | null
+      createdAt: string
+      updatedAt: string
+      creator: { login: string } | null
+      assignees: { nodes: { login: string; avatarUrl: string }[] }
+    }
+  | null
+
+interface FetchTaskDetailResponse {
+  node: {
+    id: string
+    fieldValues: { nodes: TaskDetailFieldValue[] }
+    content: TaskDetailContent
+  } | null
+}
+
+const FETCH_TASK_DETAIL_QUERY = `
+  query FetchTaskDetail($itemId: ID!) {
+    node(id: $itemId) {
+      ... on ProjectV2Item {
+        id
+        fieldValues(first: 20) {
+          nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              field { ... on ProjectV2SingleSelectField { name } }
+              name
+              optionId
+            }
+            ... on ProjectV2ItemFieldDateValue {
+              field { ... on ProjectV2FieldCommon { name } }
+              date
+            }
+            ... on ProjectV2ItemFieldTextValue {
+              field { ... on ProjectV2FieldCommon { name } }
+              text
+            }
+            ... on ProjectV2ItemFieldNumberValue {
+              field { ... on ProjectV2FieldCommon { name } }
+              number
+            }
+          }
+        }
+        content {
+          ... on Issue {
+            __typename
+            title
+            number
+            state
+            url
+            body
+            createdAt
+            updatedAt
+            author { login }
+            assignees(first: 10) { nodes { login avatarUrl } }
+            labels(first: 10) { nodes { name color } }
+          }
+          ... on DraftIssue {
+            __typename
+            title
+            body
+            createdAt
+            updatedAt
+            creator { login }
+            assignees(first: 10) { nodes { login avatarUrl } }
+          }
+        }
+      }
+    }
+  }
+`
+
+function findFieldValue(
+  nodes: TaskDetailFieldValue[],
+  fieldName: string
+): TaskDetailFieldValue | undefined {
+  return nodes.find((n) => n.field?.name?.toLowerCase() === fieldName.toLowerCase())
+}
+
+/**
+ * Fetch full detail for a single ProjectV2 item by its node ID.
+ */
+export async function fetchTaskDetail(pat: string, itemId: string): Promise<TaskDetail> {
+  const data = await githubGraphQL<FetchTaskDetailResponse>(pat, FETCH_TASK_DETAIL_QUERY, {
+    itemId,
+  })
+
+  if (!data.node) {
+    throw new Error('Task not found')
+  }
+
+  const { fieldValues, content } = data.node
+  const fieldNodes = fieldValues.nodes
+
+  const statusField = findFieldValue(fieldNodes, 'status')
+  const priorityField = findFieldValue(fieldNodes, 'priority')
+  const dueDateField = findFieldValue(fieldNodes, 'due date')
+
+  const status = statusField?.name ?? null
+  const priority = priorityField?.name ?? null
+  const dueDate = dueDateField?.date ?? null
+
+  if (!content) {
+    return {
+      id: data.node.id,
+      title: '(No title)',
+      body: null,
+      isDraft: true,
+      issueNumber: null,
+      issueState: null,
+      issueUrl: null,
+      author: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      status,
+      priority,
+      dueDate,
+      assignees: [],
+      labels: [],
+    }
+  }
+
+  if (content.__typename === 'Issue') {
+    return {
+      id: data.node.id,
+      title: content.title,
+      body: content.body,
+      isDraft: false,
+      issueNumber: content.number,
+      issueState: content.state,
+      issueUrl: content.url,
+      author: content.author?.login ?? null,
+      createdAt: content.createdAt,
+      updatedAt: content.updatedAt,
+      status,
+      priority,
+      dueDate,
+      assignees: content.assignees.nodes,
+      labels: content.labels.nodes,
+    }
+  }
+
+  // DraftIssue
+  return {
+    id: data.node.id,
+    title: content.title,
+    body: content.body,
+    isDraft: true,
+    issueNumber: null,
+    issueState: null,
+    issueUrl: null,
+    author: content.creator?.login ?? null,
+    createdAt: content.createdAt,
+    updatedAt: content.updatedAt,
+    status,
+    priority,
+    dueDate,
+    assignees: content.assignees.nodes,
+    labels: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 /** Execute a GraphQL query against the GitHub API using a PAT. */
 export async function githubGraphQL<T>(


### PR DESCRIPTION
## Summary
- Full task detail screen at `app/(app)/task/[id].tsx`: title, status badge, labels, assignees, markdown body
- New `fetchTaskDetail()` GraphQL query returns all ProjectV2Item fields (status, priority, due date, body, assignees, labels)
- Issue items show number + external link that opens GitHub in browser
- Metadata grid: priority, due date, created, updated
- Falls back to tasks-store cache for immediate title while fetching full detail
- Read-only for Phase 1 (editing comes in Phase 2)

## Test plan
- [ ] Tap any task card in the board view → task detail screen opens
- [ ] Title, status badge and labels render correctly
- [ ] Assignee avatars + logins shown
- [ ] For Issue items: issue number link is shown; tapping it opens GitHub in the browser
- [ ] For DraftIssue items: no issue link shown
- [ ] Priority and due date appear in metadata grid if set on the project item
- [ ] Markdown body renders correctly (headings, code blocks, lists, links)
- [ ] Loading spinner shown while fetching
- [ ] Kill network before tapping a task → error state with "Go back" button

Closes #6
---
🤖 Generated with [Claude Code](https://claude.com/claude-code)