### PR TITLE
feat: MMKV local caching with stale-while-revalidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-native": "0.83.4",
         "react-native-gesture-handler": "~2.30.0",
         "react-native-markdown-display": "^7.0.2",
+        "react-native-mmkv": "^4.3.0",
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
@@ -14697,6 +14698,17 @@
       "peerDependencies": {
         "react": ">=16.2.0",
         "react-native": ">=0.50.4"
+      }
+    },
+    "node_modules/react-native-mmkv": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-mmkv/-/react-native-mmkv-4.3.0.tgz",
+      "integrity": "sha512-D1wB2ViMrm+0rs7FcbLoct/BV+qugASi+XAZT8MzXy5yl0CI0qxToh2LPnw9UENHrNefpfDZgE5FpMhIB37I5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-nitro-modules": "*"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-native": "0.83.4",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-markdown-display": "^7.0.2",
+    "react-native-mmkv": "^4.3.0",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -18,6 +18,7 @@ import { useTheme } from '../../../contexts/ThemeContext'
 import { useBoardsStore } from '../../../stores/boards-store'
 import { fetchUserBoards, type Board } from '../../../lib/github'
 import { fetchGithubPAT } from '../../../lib/github-pat'
+import { getCached, setCached } from '../../../lib/cache'
 
 function formatUpdatedAt(iso: string): string {
   const date = new Date(iso)
@@ -111,6 +112,13 @@ export default function BoardsScreen() {
 
   const loadBoards = useCallback(async () => {
     if (!user?.id) return
+
+    // Serve cached data immediately so the screen renders without a spinner
+    const cached = getCached<Board[]>(['boards', user.id])
+    if (cached) {
+      setBoards(cached)
+    }
+
     setLoading(true)
     setError(null)
     try {
@@ -120,6 +128,7 @@ export default function BoardsScreen() {
         return
       }
       const result = await fetchUserBoards(pat)
+      setCached(['boards', user.id], result)
       setBoards(result)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'

--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -16,6 +16,7 @@ import { useCurrentUser } from '../../../hooks/use-current-user'
 import { fetchGithubPAT } from '../../../lib/github-pat'
 import { fetchBoardItems, groupTasksByStatus, type BoardColumn, type Task } from '../../../lib/github'
 import { useTasksStore } from '../../../stores/tasks-store'
+import { getCached, setCached } from '../../../lib/cache'
 import { useBoardsStore } from '../../../stores/boards-store'
 import { Avatar } from '../../../components/ui/Avatar'
 import { Card } from '../../../components/ui/Card'
@@ -278,6 +279,13 @@ export default function BoardScreen() {
 
   const loadTasks = useCallback(async () => {
     if (!id || !user?.id) return
+
+    // Serve cached data immediately so the screen renders without a spinner
+    const cached = getCached<Task[]>(['tasks', user.id, id])
+    if (cached) {
+      setTasks(id, cached)
+    }
+
     setLoading(true)
     setError(null)
     try {
@@ -287,6 +295,7 @@ export default function BoardScreen() {
         return
       }
       const result = await fetchBoardItems(pat, id)
+      setCached(['tasks', user.id, id], result)
       setTasks(id, result)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
@@ -302,11 +311,12 @@ export default function BoardScreen() {
     }
   }, [id, user?.id, setTasks, setLoading, setError])
 
+  // Always fetch on mount — cached data is served immediately inside loadTasks,
+  // then fresh data from the API replaces it when the request completes.
   useEffect(() => {
-    if (tasks === null) {
-      void loadTasks()
-    }
-  }, [tasks, loadTasks])
+    void loadTasks()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, user?.id])
 
   const onRefresh = useCallback(() => {
     void loadTasks()

--- a/src/app/(app)/link-github.tsx
+++ b/src/app/(app)/link-github.tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from '../../stores/auth-store'
 import { useGithubStore } from '../../stores/github-store'
 import { validatePAT } from '../../lib/github'
 import { saveGithubPAT, removeGithubPAT } from '../../lib/github-pat'
+import { clearUserCache } from '../../lib/cache'
 import { useTheme } from '../../contexts/ThemeContext'
 
 export default function LinkGithubScreen() {
@@ -84,6 +85,7 @@ export default function LinkGithubScreen() {
               Alert.alert('Error', result.error ?? 'Failed to unlink account.')
               return
             }
+            clearUserCache(user.id)
             setGithubAccount(null)
           },
         },

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,59 @@
+import { createMMKV } from 'react-native-mmkv'
+
+const storage = createMMKV({ id: 'gitlist-cache' })
+
+const TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+interface CacheEntry<T> {
+  data: T
+  cachedAt: number
+}
+
+function buildKey(parts: string[]): string {
+  return parts.join(':')
+}
+
+/**
+ * Return cached data for the given key parts, or null if absent / expired.
+ */
+export function getCached<T>(parts: string[]): T | null {
+  const key = buildKey(parts)
+  const raw = storage.getString(key)
+  if (!raw) return null
+  try {
+    const entry = JSON.parse(raw) as CacheEntry<T>
+    if (Date.now() - entry.cachedAt > TTL_MS) {
+      storage.remove(key)
+      return null
+    }
+    return entry.data
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist data under the given key parts with the current timestamp.
+ */
+export function setCached<T>(parts: string[], data: T): void {
+  const entry: CacheEntry<T> = { data, cachedAt: Date.now() }
+  storage.set(buildKey(parts), JSON.stringify(entry))
+}
+
+/**
+ * Remove a single cache entry.
+ */
+export function deleteCached(parts: string[]): void {
+  storage.remove(buildKey(parts))
+}
+
+/**
+ * Clear all cached boards and tasks for a given user.
+ * Call this when the user unlinks their PAT or changes account.
+ */
+export function clearUserCache(userId: string): void {
+  const keys = storage
+    .getAllKeys()
+    .filter((k: string) => k.startsWith(`boards:${userId}`) || k.startsWith(`tasks:${userId}`))
+  keys.forEach((k: string) => storage.remove(k))
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/cache.ts` — thin MMKV v3 wrapper with 24h TTL (getCached / setCached / deleteCached / clearUserCache)
- Boards list screen: serve cached boards immediately on mount, then fetch fresh data in the background and update the cache on success
- Task list screen: same stale-while-revalidate pattern — cached tasks appear instantly, fresh data replaces them when the API responds
- Cache cleared automatically when the user unlinks their GitHub PAT
- Cache keys: `boards:{userId}` and `tasks:{userId}:{boardId}`

## Test plan

- [ ] First open: boards and tasks load from GitHub (no cache yet)
- [ ] Close and reopen app: boards and tasks appear instantly from cache, then refresh silently in background
- [ ] Pull to refresh: triggers a fresh fetch and updates the cache
- [ ] Unlink GitHub PAT: cache is cleared — reopening the screen loads fresh data after re-linking
- [ ] Leave app idle for 24h (or manually advance clock): stale entries are evicted and fresh data is fetched

Closes #5

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)