### PR TITLE
feat: multi-board navigation, board picker, and all-boards view

### DIFF
--- a/src/app/(app)/(tabs)/index.tsx
+++ b/src/app/(app)/(tabs)/index.tsx
@@ -7,7 +7,7 @@ import {
   Pressable,
   ActivityIndicator,
 } from 'react-native'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useRouter } from 'expo-router'
 import Ionicons from '@expo/vector-icons/Ionicons'
 import { useCurrentUser } from '../../../hooks/use-current-user'
@@ -19,6 +19,7 @@ import { useBoardsStore } from '../../../stores/boards-store'
 import { fetchUserBoards, type Board } from '../../../lib/github'
 import { fetchGithubPAT } from '../../../lib/github-pat'
 import { getCached, setCached } from '../../../lib/cache'
+import { getLastBoardId, getLastViewedAt } from '../../../lib/last-board'
 
 function formatUpdatedAt(iso: string): string {
   const date = new Date(iso)
@@ -34,23 +35,33 @@ function formatUpdatedAt(iso: string): string {
 
 interface BoardCardProps {
   board: Board
+  hasUnread: boolean
   theme: ReturnType<typeof useTheme>['theme']
   onPress: () => void
 }
 
-function BoardCard({ board, theme, onPress }: BoardCardProps) {
+function BoardCard({ board, hasUnread, theme, onPress }: BoardCardProps) {
   const s = useMemo(() => cardStyles(theme), [theme])
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`Open board ${board.title}`}
+      accessibilityLabel={`Open board ${board.title}${hasUnread ? ', has recent updates' : ''}`}
     >
       <Card style={s.card}>
         <View style={s.header}>
-          <Text style={s.title} numberOfLines={2}>
-            {board.title}
-          </Text>
+          <View style={s.titleRow}>
+            <Text style={s.title} numberOfLines={2}>
+              {board.title}
+            </Text>
+            {hasUnread && (
+              <View
+                style={s.unreadDot}
+                accessibilityLabel="Recent updates"
+                accessibilityRole="image"
+              />
+            )}
+          </View>
           <Badge
             label={`${board.itemCount} item${board.itemCount !== 1 ? 's' : ''}`}
             variant="secondary"
@@ -70,10 +81,44 @@ function BoardCard({ board, theme, onPress }: BoardCardProps) {
 function cardStyles(theme: ReturnType<typeof useTheme>['theme']) {
   return StyleSheet.create({
     card: { marginBottom: spacing[3] },
-    header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: spacing[3] },
-    title: { flex: 1, fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, fontWeight: '600', color: theme.colors.foreground },
-    description: { marginTop: spacing[1], fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground },
-    updatedAt: { marginTop: spacing[2], fontSize: fontSize.xs.size, lineHeight: fontSize.xs.lineHeight, color: theme.colors.mutedForeground },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      gap: spacing[3],
+    },
+    titleRow: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing[2],
+    },
+    title: {
+      flex: 1,
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    unreadDot: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: theme.colors.primary,
+      flexShrink: 0,
+    },
+    description: {
+      marginTop: spacing[1],
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+    },
+    updatedAt: {
+      marginTop: spacing[2],
+      fontSize: fontSize.xs.size,
+      lineHeight: fontSize.xs.lineHeight,
+      color: theme.colors.mutedForeground,
+    },
   })
 }
 
@@ -94,7 +139,12 @@ function SkeletonCard({ theme }: { theme: ReturnType<typeof useTheme>['theme'] }
 function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
   return StyleSheet.create({
     card: { marginBottom: spacing[3] },
-    titleRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing[3] },
+    titleRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: spacing[3],
+    },
     shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
     titleBlock: { flex: 1, height: 18 },
     badgeBlock: { width: 64, height: 22, borderRadius: 99 },
@@ -109,11 +159,11 @@ export default function BoardsScreen() {
   const router = useRouter()
   const { boards, isLoading, error, setBoards, setLoading, setError } = useBoardsStore()
   const s = useMemo(() => styles(theme), [theme])
+  const didRedirect = useRef(false)
 
   const loadBoards = useCallback(async () => {
     if (!user?.id) return
 
-    // Serve cached data immediately so the screen renders without a spinner
     const cached = getCached<Board[]>(['boards', user.id])
     if (cached) {
       setBoards(cached)
@@ -148,9 +198,41 @@ export default function BoardsScreen() {
     void loadBoards()
   }, [loadBoards])
 
+  // On first render, redirect to the last-viewed board if one is saved
+  useEffect(() => {
+    if (!user?.id || didRedirect.current) return
+    const lastId = getLastBoardId(user.id)
+    if (lastId) {
+      didRedirect.current = true
+      router.push({ pathname: '/(app)/board/[id]', params: { id: lastId } })
+    }
+  }, [user?.id, router])
+
   const onRefresh = useCallback(() => {
     void loadBoards()
   }, [loadBoards])
+
+  const navigateToBoard = useCallback(
+    (boardId: string) => {
+      router.push({ pathname: '/(app)/board/[id]', params: { id: boardId } })
+    },
+    [router]
+  )
+
+  // Compute unread state per board based on MMKV last-viewed timestamps
+  const unreadBoardIds = useMemo(() => {
+    if (!user?.id) return new Set<string>()
+    const ids = new Set<string>()
+    for (const board of boards) {
+      const lastViewedAt = getLastViewedAt(user.id, board.id)
+      if (lastViewedAt === null) continue // Never viewed — not "unread", just new
+      const boardUpdatedAt = new Date(board.updatedAt).getTime()
+      if (boardUpdatedAt > lastViewedAt) {
+        ids.add(board.id)
+      }
+    }
+    return ids
+  }, [boards, user?.id])
 
   if (isLoading && boards.length === 0) {
     return (
@@ -194,12 +276,13 @@ export default function BoardsScreen() {
       data={boards}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
-          <BoardCard
-            board={item}
-            theme={theme}
-            onPress={() => router.push(`/(app)/board/${item.id}`)}
-          />
-        )}
+        <BoardCard
+          board={item}
+          hasUnread={unreadBoardIds.has(item.id)}
+          theme={theme}
+          onPress={() => navigateToBoard(item.id)}
+        />
+      )}
       refreshControl={
         <RefreshControl
           refreshing={isLoading}
@@ -226,12 +309,53 @@ function styles(theme: ReturnType<typeof useTheme>['theme']) {
     content: { padding: spacing[5] },
     centered: { justifyContent: 'center', alignItems: 'center', padding: spacing[8] },
     emptyContainer: { flex: 1, padding: spacing[5] },
-    emptyInner: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: spacing[3] },
-    emptyTitle: { fontSize: fontSize.lg.size, lineHeight: fontSize.lg.lineHeight, fontWeight: '600', color: theme.colors.foreground },
-    emptyBody: { fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground, textAlign: 'center' },
-    errorTitle: { marginTop: spacing[4], fontSize: fontSize.lg.size, lineHeight: fontSize.lg.lineHeight, fontWeight: '600', color: theme.colors.foreground },
-    errorBody: { marginTop: spacing[2], fontSize: fontSize.sm.size, lineHeight: fontSize.sm.lineHeight, color: theme.colors.mutedForeground, textAlign: 'center' },
-    retryButton: { marginTop: spacing[6], backgroundColor: theme.colors.primary, paddingVertical: spacing[3], paddingHorizontal: spacing[6], borderRadius: 12, minHeight: 44, justifyContent: 'center', alignItems: 'center' },
-    retryLabel: { fontSize: fontSize.base.size, lineHeight: fontSize.base.lineHeight, fontWeight: '600', color: colors.surface.background },
+    emptyInner: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      gap: spacing[3],
+    },
+    emptyTitle: {
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    emptyBody: {
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
+    },
+    errorTitle: {
+      marginTop: spacing[4],
+      fontSize: fontSize.lg.size,
+      lineHeight: fontSize.lg.lineHeight,
+      fontWeight: '600',
+      color: theme.colors.foreground,
+    },
+    errorBody: {
+      marginTop: spacing[2],
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
+    },
+    retryButton: {
+      marginTop: spacing[6],
+      backgroundColor: theme.colors.primary,
+      paddingVertical: spacing[3],
+      paddingHorizontal: spacing[6],
+      borderRadius: 12,
+      minHeight: 44,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    retryLabel: {
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      fontWeight: '600',
+      color: colors.surface.background,
+    },
   })
 }

--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -10,6 +10,8 @@ import {
   Platform,
   Keyboard,
   TextInput as RNTextInput,
+  Modal,
+  FlatList,
 } from 'react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
@@ -32,8 +34,12 @@ import { useTasksStore } from '../../../stores/tasks-store'
 import { useFieldsStore } from '../../../stores/fields-store'
 import { getCached, setCached } from '../../../lib/cache'
 import { useBoardsStore } from '../../../stores/boards-store'
+import { setLastBoardId, setLastViewedAt } from '../../../lib/last-board'
 import { Avatar } from '../../../components/ui/Avatar'
 import { Card } from '../../../components/ui/Card'
+
+const ALL_BOARDS_ID = 'all'
+const MAX_ITEMS_PER_BOARD = 50
 
 // ---------------------------------------------------------------------------
 // Skeleton
@@ -58,7 +64,12 @@ function SkeletonTaskCard({ theme }: { theme: ReturnType<typeof useTheme>['theme
 function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
   return StyleSheet.create({
     card: { marginBottom: spacing[2] },
-    titleRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: spacing[3] },
+    titleRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: spacing[3],
+    },
     row: { flexDirection: 'row', gap: spacing[2], marginTop: spacing[2] },
     shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
     titleBlock: { flex: 1, height: 16 },
@@ -404,6 +415,171 @@ function quickAddStyles(theme: ReturnType<typeof useTheme>['theme'], bottomInset
 }
 
 // ---------------------------------------------------------------------------
+// Board picker modal
+// ---------------------------------------------------------------------------
+
+interface BoardPickerModalProps {
+  currentBoardId: string
+  onSelect: (boardId: string) => void
+  onClose: () => void
+  theme: ReturnType<typeof useTheme>['theme']
+}
+
+interface PickerBoardItem {
+  id: string
+  title: string
+  isAllBoards?: boolean
+}
+
+function BoardPickerModal({ currentBoardId, onSelect, onClose, theme }: BoardPickerModalProps) {
+  const boards = useBoardsStore((state) => state.boards)
+  const insets = useSafeAreaInsets()
+  const s = useMemo(() => pickerStyles(theme), [theme])
+
+  const items: PickerBoardItem[] = [
+    { id: ALL_BOARDS_ID, title: 'All boards', isAllBoards: true },
+    ...boards.map((b) => ({ id: b.id, title: b.title })),
+  ]
+
+  return (
+    <Modal
+      visible
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <Pressable style={s.backdrop} onPress={onClose} accessibilityLabel="Close" />
+      <View style={[s.sheet, { paddingBottom: insets.bottom + spacing[4] }]}>
+        <View style={s.handle} />
+        <View style={s.header}>
+          <Text style={s.title}>Switch Board</Text>
+          <Pressable
+            onPress={onClose}
+            style={s.closeButton}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+          >
+            <Text style={s.closeLabel}>Cancel</Text>
+          </Pressable>
+        </View>
+        <FlatList
+          data={items}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => {
+            const isSelected = item.id === currentBoardId
+            return (
+              <Pressable
+                style={[s.boardRow, isSelected && s.boardRowSelected]}
+                onPress={() => onSelect(item.id)}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: isSelected }}
+                accessibilityLabel={item.title}
+              >
+                {item.isAllBoards ? (
+                  <Ionicons
+                    name="albums-outline"
+                    size={20}
+                    color={isSelected ? theme.colors.primary : theme.colors.mutedForeground}
+                    style={s.boardIcon}
+                  />
+                ) : (
+                  <Ionicons
+                    name="git-branch-outline"
+                    size={20}
+                    color={isSelected ? theme.colors.primary : theme.colors.mutedForeground}
+                    style={s.boardIcon}
+                  />
+                )}
+                <Text style={[s.boardName, isSelected && s.boardNameSelected]}>
+                  {item.title}
+                </Text>
+                {isSelected && (
+                  <Ionicons name="checkmark" size={18} color={theme.colors.primary} />
+                )}
+              </Pressable>
+            )
+          }}
+          style={s.list}
+        />
+      </View>
+    </Modal>
+  )
+}
+
+function pickerStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: 'rgba(0,0,0,0.4)',
+    },
+    sheet: {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: theme.colors.card,
+      borderTopLeftRadius: 16,
+      borderTopRightRadius: 16,
+      maxHeight: '60%',
+    },
+    handle: {
+      width: 40,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: theme.colors.border,
+      alignSelf: 'center',
+      marginTop: spacing[3],
+      marginBottom: spacing[2],
+    },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingHorizontal: spacing[5],
+      paddingBottom: spacing[3],
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: theme.colors.border,
+    },
+    title: {
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      fontWeight: '700',
+      color: theme.colors.foreground,
+    },
+    closeButton: { paddingVertical: spacing[1], paddingLeft: spacing[4] },
+    closeLabel: {
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      color: theme.colors.primary,
+    },
+    list: { flexGrow: 0 },
+    boardRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: spacing[4],
+      paddingHorizontal: spacing[5],
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: theme.colors.border,
+    },
+    boardRowSelected: {
+      backgroundColor: theme.colors.primary + '0d',
+    },
+    boardIcon: { marginRight: spacing[3] },
+    boardName: {
+      flex: 1,
+      fontSize: fontSize.base.size,
+      lineHeight: fontSize.base.lineHeight,
+      color: theme.colors.foreground,
+    },
+    boardNameSelected: {
+      color: theme.colors.primary,
+      fontWeight: '600',
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Main screen
 // ---------------------------------------------------------------------------
 
@@ -414,6 +590,8 @@ export default function BoardScreen() {
   const router = useRouter()
   const navigation = useNavigation()
   const insets = useSafeAreaInsets()
+
+  const [pickerVisible, setPickerVisible] = useState(false)
 
   const {
     tasksByBoard,
@@ -429,17 +607,38 @@ export default function BoardScreen() {
   const setFields = useFieldsStore((state) => state.setFields)
   const boards = useBoardsStore((state) => state.boards)
 
-  const tasks = id ? (tasksByBoard[id] ?? null) : null
-  const board = id ? boards.find((b) => b.id === id) : undefined
+  const isAllBoards = id === ALL_BOARDS_ID
+  const board = isAllBoards ? undefined : boards.find((b) => b.id === id)
 
+  // Persist last-viewed board and record view timestamp
   useEffect(() => {
-    if (board?.title) {
-      navigation.setOptions({ title: board.title })
-    }
-  }, [board?.title, navigation])
+    if (!id || !user?.id || isAllBoards) return
+    setLastBoardId(user.id, id)
+    setLastViewedAt(user.id, id)
+  }, [id, user?.id, isAllBoards])
+
+  // Set tappable header title
+  useEffect(() => {
+    const title = isAllBoards ? 'All Boards' : (board?.title ?? 'Board')
+    navigation.setOptions({
+      headerTitle: () => (
+        <Pressable
+          onPress={() => setPickerVisible(true)}
+          style={headerTitleStyles.button}
+          accessibilityRole="button"
+          accessibilityLabel={`${title} — tap to switch board`}
+        >
+          <Text style={[headerTitleStyles.text, { color: theme.colors.foreground }]}>
+            {title}
+          </Text>
+          <Ionicons name="chevron-down" size={14} color={theme.colors.mutedForeground} />
+        </Pressable>
+      ),
+    })
+  }, [board?.title, isAllBoards, navigation, theme])
 
   const loadTasks = useCallback(async () => {
-    if (!id || !user?.id) return
+    if (!id || !user?.id || isAllBoards) return
 
     const cached = getCached<Task[]>(['tasks', user.id, id])
     if (cached) {
@@ -473,16 +672,67 @@ export default function BoardScreen() {
         setError(`Failed to load tasks: ${message}`)
       }
     }
-  }, [id, user?.id, setTasks, setLoading, setError, setFields])
+  }, [id, user?.id, isAllBoards, setTasks, setLoading, setError, setFields])
+
+  // Load tasks for all boards when in aggregate view
+  const loadAllBoardsTasks = useCallback(async () => {
+    if (!isAllBoards || !user?.id || boards.length === 0) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      const pat = await fetchGithubPAT(user.id)
+      if (!pat) {
+        setError('Could not retrieve your GitHub token. Try relinking your account.')
+        return
+      }
+      // Serve cached data first
+      for (const b of boards) {
+        const cached = getCached<Task[]>(['tasks', user.id, b.id])
+        if (cached && !tasksByBoard[b.id]) {
+          setTasks(b.id, cached)
+        }
+      }
+      // Fetch all boards in parallel — only those not already loaded
+      const unloaded = boards.filter((b) => !tasksByBoard[b.id])
+      await Promise.all(
+        unloaded.map(async (b) => {
+          const result = await fetchBoardItems(pat, b.id)
+          setCached(['tasks', user.id, b.id], result)
+          setTasks(b.id, result)
+        })
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setError(`Failed to load tasks: ${message}`)
+    }
+  }, [isAllBoards, user?.id, boards, tasksByBoard, setTasks, setLoading, setError])
 
   useEffect(() => {
-    void loadTasks()
+    if (isAllBoards) {
+      void loadAllBoardsTasks()
+    } else {
+      void loadTasks()
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, user?.id])
 
   const onRefresh = useCallback(() => {
-    void loadTasks()
-  }, [loadTasks])
+    if (isAllBoards) {
+      void loadAllBoardsTasks()
+    } else {
+      void loadTasks()
+    }
+  }, [isAllBoards, loadAllBoardsTasks, loadTasks])
+
+  const handleBoardSelect = useCallback(
+    (boardId: string) => {
+      setPickerVisible(false)
+      if (boardId === id) return
+      router.replace({ pathname: '/(app)/board/[id]', params: { id: boardId } })
+    },
+    [id, router]
+  )
 
   const handleQuickAdd = useCallback(
     async (title: string) => {
@@ -527,6 +777,8 @@ export default function BoardScreen() {
   const { theme: t } = useTheme()
   const s = useMemo(() => styles(t), [t])
 
+  const tasks = isAllBoards ? null : (id ? (tasksByBoard[id] ?? null) : null)
+
   const columns: BoardColumn[] = useMemo(
     () => (tasks ? groupTasksByStatus(tasks) : []),
     [tasks]
@@ -537,66 +789,30 @@ export default function BoardScreen() {
     [columns]
   )
 
-  // Loading skeleton — no quick-add during initial load
-  if (isLoading && tasks === null) {
-    return (
-      <View style={s.container}>
-        <SkeletonSection theme={theme} />
-        <SkeletonSection theme={theme} />
-        <SkeletonSection theme={theme} />
-      </View>
-    )
-  }
+  // Aggregate sections for "All Boards" view
+  const allBoardsSections = useMemo(() => {
+    if (!isAllBoards) return []
+    return boards
+      .map((b) => {
+        const boardTasks = (tasksByBoard[b.id] ?? []).slice(0, MAX_ITEMS_PER_BOARD)
+        return { title: b.title, data: boardTasks, count: boardTasks.length, boardId: b.id }
+      })
+      .filter((sec) => sec.data.length > 0)
+  }, [isAllBoards, boards, tasksByBoard])
 
-  // Hard error with no cached data — no quick-add
-  if (error && tasks === null) {
+  // ---- All Boards view ----
+  if (isAllBoards) {
     return (
-      <View style={[s.container, s.centered]}>
-        <Ionicons name="alert-circle-outline" size={48} color={theme.colors.mutedForeground} />
-        <Text style={s.errorTitle}>Something went wrong</Text>
-        <Text style={s.errorBody}>{error}</Text>
-        <Pressable
-          style={s.retryButton}
-          onPress={onRefresh}
-          accessibilityRole="button"
-          accessibilityLabel="Retry loading tasks"
-        >
-          {isLoading ? (
-            <ActivityIndicator color={colors.surface.background} size="small" />
-          ) : (
-            <Text style={s.retryLabel}>Try again</Text>
-          )}
-        </Pressable>
-      </View>
-    )
-  }
-
-  // Empty state + task list — both include the quick-add bar
-  return (
-    <KeyboardAvoidingView
-      style={s.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
-    >
-      {tasks !== null && tasks.length === 0 ? (
-        <View style={[s.container, s.centered]}>
-          <Ionicons name="checkmark-circle-outline" size={48} color={theme.colors.mutedForeground} />
-          <Text style={s.emptyTitle}>No items yet</Text>
-          <Text style={s.emptyBody}>
-            Add your first task below or add issues to this board in GitHub.
-          </Text>
-        </View>
-      ) : (
+      <>
         <SectionList
           style={s.container}
           contentContainerStyle={s.content}
-          sections={sections}
+          sections={allBoardsSections}
           keyExtractor={(item) => item.id}
-          keyboardShouldPersistTaps="handled"
           renderSectionHeader={({ section }) => (
             <SectionHeader title={section.title} count={section.count} theme={theme} />
           )}
-          renderItem={({ item }) => (
+          renderItem={({ item, section }) => (
             <View style={s.taskPadding}>
               <TaskCard
                 task={item}
@@ -604,7 +820,7 @@ export default function BoardScreen() {
                 onPress={() =>
                   router.push({
                     pathname: '/(app)/task/[id]',
-                    params: { id: item.id, boardId: id },
+                    params: { id: item.id, boardId: (section as { boardId: string }).boardId },
                   })
                 }
               />
@@ -618,17 +834,173 @@ export default function BoardScreen() {
             />
           }
           stickySectionHeadersEnabled
+          ListEmptyComponent={
+            isLoading ? (
+              <View style={s.container}>
+                <SkeletonSection theme={theme} />
+                <SkeletonSection theme={theme} />
+              </View>
+            ) : (
+              <View style={s.centered}>
+                <Ionicons name="albums-outline" size={48} color={theme.colors.mutedForeground} />
+                <Text style={s.emptyTitle}>No tasks across boards</Text>
+                <Text style={s.emptyBody}>
+                  Add items to your GitHub boards and they will appear here.
+                </Text>
+              </View>
+            )
+          }
+        />
+        {pickerVisible && (
+          <BoardPickerModal
+            currentBoardId={ALL_BOARDS_ID}
+            onSelect={handleBoardSelect}
+            onClose={() => setPickerVisible(false)}
+            theme={theme}
+          />
+        )}
+      </>
+    )
+  }
+
+  // ---- Single Board view ----
+
+  // Loading skeleton — no quick-add during initial load
+  if (isLoading && tasks === null) {
+    return (
+      <>
+        <View style={s.container}>
+          <SkeletonSection theme={theme} />
+          <SkeletonSection theme={theme} />
+          <SkeletonSection theme={theme} />
+        </View>
+        {pickerVisible && (
+          <BoardPickerModal
+            currentBoardId={id ?? ''}
+            onSelect={handleBoardSelect}
+            onClose={() => setPickerVisible(false)}
+            theme={theme}
+          />
+        )}
+      </>
+    )
+  }
+
+  // Hard error with no cached data — no quick-add
+  if (error && tasks === null) {
+    return (
+      <>
+        <View style={[s.container, s.centered]}>
+          <Ionicons name="alert-circle-outline" size={48} color={theme.colors.mutedForeground} />
+          <Text style={s.errorTitle}>Something went wrong</Text>
+          <Text style={s.errorBody}>{error}</Text>
+          <Pressable
+            style={s.retryButton}
+            onPress={onRefresh}
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading tasks"
+          >
+            {isLoading ? (
+              <ActivityIndicator color={colors.surface.background} size="small" />
+            ) : (
+              <Text style={s.retryLabel}>Try again</Text>
+            )}
+          </Pressable>
+        </View>
+        {pickerVisible && (
+          <BoardPickerModal
+            currentBoardId={id ?? ''}
+            onSelect={handleBoardSelect}
+            onClose={() => setPickerVisible(false)}
+            theme={theme}
+          />
+        )}
+      </>
+    )
+  }
+
+  // Empty state + task list — both include the quick-add bar
+  return (
+    <>
+      <KeyboardAvoidingView
+        style={s.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
+      >
+        {tasks !== null && tasks.length === 0 ? (
+          <View style={[s.container, s.centered]}>
+            <Ionicons name="checkmark-circle-outline" size={48} color={theme.colors.mutedForeground} />
+            <Text style={s.emptyTitle}>No items yet</Text>
+            <Text style={s.emptyBody}>
+              Add your first task below or add issues to this board in GitHub.
+            </Text>
+          </View>
+        ) : (
+          <SectionList
+            style={s.container}
+            contentContainerStyle={s.content}
+            sections={sections}
+            keyExtractor={(item) => item.id}
+            keyboardShouldPersistTaps="handled"
+            renderSectionHeader={({ section }) => (
+              <SectionHeader title={section.title} count={section.count} theme={theme} />
+            )}
+            renderItem={({ item }) => (
+              <View style={s.taskPadding}>
+                <TaskCard
+                  task={item}
+                  theme={theme}
+                  onPress={() =>
+                    router.push({
+                      pathname: '/(app)/task/[id]',
+                      params: { id: item.id, boardId: id },
+                    })
+                  }
+                />
+              </View>
+            )}
+            refreshControl={
+              <RefreshControl
+                refreshing={isLoading}
+                onRefresh={onRefresh}
+                tintColor={theme.colors.primary}
+              />
+            }
+            stickySectionHeadersEnabled
+          />
+        )}
+
+        <QuickAddBar
+          onSubmit={handleQuickAdd}
+          theme={theme}
+          bottomInset={insets.bottom}
+        />
+      </KeyboardAvoidingView>
+      {pickerVisible && (
+        <BoardPickerModal
+          currentBoardId={id ?? ''}
+          onSelect={handleBoardSelect}
+          onClose={() => setPickerVisible(false)}
+          theme={theme}
         />
       )}
-
-      <QuickAddBar
-        onSubmit={handleQuickAdd}
-        theme={theme}
-        bottomInset={insets.bottom}
-      />
-    </KeyboardAvoidingView>
+    </>
   )
 }
+
+const headerTitleStyles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 4,
+    paddingHorizontal: 2,
+  },
+  text: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+})
 
 function styles(theme: ReturnType<typeof useTheme>['theme']) {
   return StyleSheet.create({
@@ -636,6 +1008,7 @@ function styles(theme: ReturnType<typeof useTheme>['theme']) {
     content: { paddingBottom: spacing[4] },
     taskPadding: { paddingHorizontal: spacing[5], paddingTop: spacing[2] },
     centered: {
+      flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
       padding: spacing[8],

--- a/src/lib/last-board.ts
+++ b/src/lib/last-board.ts
@@ -1,0 +1,28 @@
+import { createMMKV } from 'react-native-mmkv'
+
+const storage = createMMKV({ id: 'gitlist-nav' })
+
+/** Persist and retrieve the last-viewed board ID for a user. */
+export function getLastBoardId(userId: string): string | null {
+  return storage.getString(`last-board:${userId}`) ?? null
+}
+
+export function setLastBoardId(userId: string, boardId: string): void {
+  storage.set(`last-board:${userId}`, boardId)
+}
+
+/**
+ * Record when a board was last viewed (epoch ms).
+ * Used to compute unread/changed indicators on the board list.
+ */
+export function setLastViewedAt(userId: string, boardId: string): void {
+  storage.set(`last-viewed:${userId}:${boardId}`, String(Date.now()))
+}
+
+/** Returns the last-viewed epoch ms for a board, or null if never viewed. */
+export function getLastViewedAt(userId: string, boardId: string): number | null {
+  const raw = storage.getString(`last-viewed:${userId}:${boardId}`)
+  if (!raw) return null
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}


### PR DESCRIPTION
## Summary

- Tappable board title in header opens `BoardPickerModal` (bottom sheet listing all boards + "All boards")
- Selecting a board navigates via `router.replace` for a clean stack; "All boards" shows tasks grouped by board name in a `SectionList`
- New `src/lib/last-board.ts` persists last-viewed board ID and per-board view timestamps in MMKV (`gitlist-nav` instance)
- Boards list screen redirects to the last-viewed board on first mount; unread dot indicator shown when `board.updatedAt > lastViewedAt`

## Test plan

- [ ] Open app → auto-redirects to last board (or stays on boards list if first run)
- [ ] Tap board name in header → picker modal opens with all boards + "All boards" option
- [ ] Select a different board → board view updates, header title changes, back stack stays clean
- [ ] Select "All boards" → tasks grouped by board name, header shows "All boards"
- [ ] View a board, background the app, re-open → no unread dot (already seen)
- [ ] Update a board item externally (GitHub), pull-to-refresh → unread dot appears on boards list
- [ ] Type-check passes (only pre-existing Sentry errors)

Closes #14