### PR TITLE
feat: add quick-add task bar to board screen

### DIFF
--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -639,7 +639,7 @@ function QuickAddBar({ onSubmit, theme, bottomInset }: QuickAddBarProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const inputRef = useRef<import('react-native').TextInput>(null)
+  const inputRef = useRef<TextInput>(null)
   const s = useMemo(() => quickAddStyles(theme, bottomInset), [theme, bottomInset])
 
   const showError = useCallback((msg: string) => {
@@ -655,7 +655,6 @@ function QuickAddBar({ onSubmit, theme, bottomInset }: QuickAddBarProps) {
     setIsSubmitting(true)
     const submitted = trimmed
     setTitle('')
-    Keyboard.dismiss()
 
     try {
       await onSubmit(submitted)


### PR DESCRIPTION
## Summary

- Persistent quick-add bar anchored above the keyboard on the board screen
- Optimistic UI: tasks appear instantly in the first status column (not "No Status")
- Input auto-refocuses after each submission for rapid task entry
- Haptic feedback on success; error banner with auto-dismiss on failure
- Keyboard-aware positioning via `useBottomTabBarHeight` + safe area insets

## Changes

- `src/app/(app)/board/[id].tsx` — QuickAddBar component, handleQuickAdd handler, optimistic task with correct first-column status

## Testing

1. Open any board
2. Tap the add input at the bottom
3. Type a task title and submit — task should appear in first column immediately
4. Input should auto-refocus for rapid entry

Closes #28

---
This PR was created by Claude Code. Please review before merging.