### PR TITLE
fix: add back buttons to navigation stack screens

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -6,19 +6,19 @@ export default function AppLayout() {
       <Stack.Screen name="(tabs)" />
       <Stack.Screen
         name="profile"
-        options={{ headerShown: true, title: 'Profile', presentation: 'card' }}
+        options={{ headerShown: true, title: 'Profile', presentation: 'card', headerBackVisible: true }}
       />
       <Stack.Screen
         name="settings"
-        options={{ headerShown: true, title: 'Settings', presentation: 'card' }}
+        options={{ headerShown: true, title: 'Settings', presentation: 'card', headerBackVisible: true }}
       />
       <Stack.Screen
         name="board"
-        options={{ headerShown: true, presentation: 'card' }}
+        options={{ headerShown: true, presentation: 'card', headerBackVisible: true }}
       />
       <Stack.Screen
         name="task"
-        options={{ headerShown: true, presentation: 'card' }}
+        options={{ headerShown: true, presentation: 'card', headerBackVisible: true }}
       />
     </Stack>
   )


### PR DESCRIPTION
## Summary
- Back buttons were absent on board, task, profile, and settings screens
- Root cause: `headerBackVisible` was not set in `(app)/_layout.tsx` Stack.Screen options

## Changes
- `src/app/(app)/_layout.tsx` — added `headerBackVisible: true` to profile, settings, board, and task screens
- `board/[id].tsx` and `task/[id].tsx` navigation.setOptions() calls do not set `headerLeft`, so the default back button is preserved

## Testing
- Open app → tap into a board → back button appears in header
- Tap into a task → back button appears
- Navigate to Settings or Profile → back button appears
- Tapping back returns to previous screen correctly

Closes #39

---
This PR was created by Claude Code via /work-all.