### PR TITLE
fix: revert to Swipeable (ReanimatedSwipeable crashes Expo Go)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,21 @@ Platform-native feel — follows iOS HIG and Material Design guidelines.
 Uses system fonts, native navigation patterns, and platform-appropriate
 styling (e.g. elevation on Android, shadows on iOS).
 
+## ⛔ BANNED IMPORTS — READ THIS BEFORE WRITING ANY CODE
+
+These imports WILL crash the app in Expo Go. **NEVER use them:**
+
+| BANNED                                                        | USE INSTEAD                                          |
+|---------------------------------------------------------------|------------------------------------------------------|
+| `react-native-gesture-handler/ReanimatedSwipeable`            | `react-native-gesture-handler/Swipeable`             |
+| `import { type SwipeableMethods }`                            | `import Swipeable` (use `Swipeable` as the ref type) |
+| `react-native-reanimated` (v4 worklet APIs)                   | Stick to reanimated v3 (no worklets)                 |
+| `react-native-mmkv`                                           | `@react-native-async-storage/async-storage`          |
+| `@sentry/react-native`                                        | `src/lib/sentry.ts` (no-op stub)                     |
+
+This has been violated 3 times already. If you import `ReanimatedSwipeable`, the app
+crashes with "[Reanimated] Failed to create a worklet". CHECK YOUR IMPORTS.
+
 ## Expo Go compatibility
 
 Development currently uses Expo Go (no native modules). Key constraints:

--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -15,7 +15,7 @@ import {
 } from 'react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router'
-import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable'
+import Swipeable from 'react-native-gesture-handler/Swipeable'
 import Ionicons from '@expo/vector-icons/Ionicons'
 import * as Haptics from 'expo-haptics'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -430,7 +430,7 @@ function SwipeableRow({
   onComplete,
   onDelete,
 }: SwipeableRowProps) {
-  const swipeableRef = useRef<SwipeableMethods | null>(null)
+  const swipeableRef = useRef<Swipeable | null>(null)
 
   const handleSwipeOpen = useCallback(
     (direction: 'left' | 'right') => {
@@ -446,7 +446,7 @@ function SwipeableRow({
 
   return (
     <View style={rowStyles.padding}>
-      <ReanimatedSwipeable
+      <Swipeable
         ref={swipeableRef}
         renderLeftActions={canComplete ? () => <CompleteAction /> : undefined}
         renderRightActions={() => <DeleteAction />}
@@ -458,7 +458,7 @@ function SwipeableRow({
         overshootRight={false}
       >
         <TaskCard task={task} theme={theme} isCompleting={isCompleting} onPress={onPress} />
-      </ReanimatedSwipeable>
+      </Swipeable>
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- `ReanimatedSwipeable` requires native worklet support which is unavailable in Expo Go — importing it crashes the app with "[Reanimated] Failed to create a worklet"
- Reverts `board/[id].tsx` back to the plain `Swipeable` import from `react-native-gesture-handler/Swipeable`
- Adds a **BANNED IMPORTS** section to `CLAUDE.md` so this regression doesn't happen a fourth time

## Changes
- `src/app/(app)/board/[id].tsx` — `ReanimatedSwipeable` → `Swipeable`, `SwipeableMethods` ref type → `Swipeable`
- `CLAUDE.md` — banned imports table with correct alternatives

## Testing
- Open board screen in Expo Go — swipe gestures should work without a crash

---
This PR was created by Claude Code. Please review before merging.