### PR TITLE
feat: empty and error states audit

### DIFF
--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -1466,7 +1466,7 @@ function BoardScreenInner() {
       } else if (message.toLowerCase().includes('network') || message.toLowerCase().includes('fetch')) {
         setError('Network error. Check your connection and try again.')
       } else {
-        setError(`Failed to load tasks: ${message}`)
+        setError('Failed to load tasks. Please try again.')
       }
     }
   }, [id, user?.id, isAllBoards, setTasks, setLoading, setError, setFields])
@@ -1496,9 +1496,8 @@ function BoardScreenInner() {
           setTasks(b.id, result)
         })
       )
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      setError(`Failed to load tasks: ${message}`)
+    } catch {
+      setError('Failed to load tasks. Please try again.')
     }
   }, [isAllBoards, user?.id, boards, tasksByBoard, setTasks, setLoading, setError])
 

--- a/src/app/(app)/task/[id].tsx
+++ b/src/app/(app)/task/[id].tsx
@@ -42,6 +42,47 @@ import { Avatar } from '../../../components/ui/Avatar'
 const EXCLUDED_FIELD_NAMES = new Set(['title', 'status', 'assignees', 'labels'])
 
 // ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function TaskDetailSkeleton({ theme }: { theme: ReturnType<typeof useTheme>['theme'] }) {
+  const s = useMemo(() => skeletonStyles(theme), [theme])
+  return (
+    <View style={s.container}>
+      {/* Title */}
+      <View style={[s.shimmer, s.title]} />
+      <View style={[s.shimmer, s.titleShort]} />
+      {/* Status badge */}
+      <View style={[s.shimmer, s.badge]} />
+      {/* Section */}
+      <View style={[s.shimmer, s.sectionLabel]} />
+      <View style={[s.shimmer, s.fieldRow]} />
+      <View style={[s.shimmer, s.fieldRow]} />
+      <View style={[s.shimmer, s.fieldRow]} />
+      {/* Meta */}
+      <View style={s.metaRow}>
+        <View style={[s.shimmer, s.meta]} />
+        <View style={[s.shimmer, s.meta]} />
+      </View>
+    </View>
+  )
+}
+
+function skeletonStyles(theme: ReturnType<typeof useTheme>['theme']) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background, padding: spacing[5] },
+    shimmer: { backgroundColor: theme.colors.muted, borderRadius: 6 },
+    title: { height: 28, width: '90%', marginBottom: spacing[2] },
+    titleShort: { height: 28, width: '60%', marginBottom: spacing[4] },
+    badge: { height: 24, width: 80, borderRadius: 99, marginBottom: spacing[6] },
+    sectionLabel: { height: 12, width: '25%', marginBottom: spacing[3] },
+    fieldRow: { height: 44, marginBottom: spacing[2], borderRadius: 8 },
+    metaRow: { flexDirection: 'row', gap: spacing[4], marginTop: spacing[4] },
+    meta: { height: 14, width: 100 },
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Label chip
 // ---------------------------------------------------------------------------
 
@@ -617,7 +658,7 @@ export default function TaskDetailScreen() {
       } else if (message.toLowerCase().includes('not found')) {
         setError('This task could not be found.')
       } else {
-        setError(`Failed to load task: ${message}`)
+        setError('Failed to load task. Please try again.')
       }
     } finally {
       setIsLoading(false)
@@ -744,11 +785,7 @@ export default function TaskDetailScreen() {
   const markdownStyles = useMemo(() => buildMarkdownStyles(theme), [theme])
 
   if (isLoading && !detail) {
-    return (
-      <View style={[s.container, s.centered]}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-      </View>
-    )
+    return <TaskDetailSkeleton theme={theme} />
   }
 
   if (error && !detail) {
@@ -759,11 +796,23 @@ export default function TaskDetailScreen() {
         <Text style={s.errorBody}>{error}</Text>
         <Pressable
           style={s.actionButton}
+          onPress={() => void loadDetail()}
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+        >
+          {isLoading ? (
+            <ActivityIndicator color={colors.surface.background} size="small" />
+          ) : (
+            <Text style={s.actionButtonLabel}>Try again</Text>
+          )}
+        </Pressable>
+        <Pressable
+          style={s.backLink}
           onPress={() => router.back()}
           accessibilityRole="button"
           accessibilityLabel="Go back"
         >
-          <Text style={s.actionButtonLabel}>Go back</Text>
+          <Text style={s.backLinkLabel}>Go back</Text>
         </Pressable>
       </View>
     )
@@ -1097,6 +1146,19 @@ function styles(
       lineHeight: fontSize.base.lineHeight,
       fontWeight: '600',
       color: colors.surface.background,
+    },
+    backLink: {
+      marginTop: spacing[3],
+      paddingVertical: spacing[2],
+      paddingHorizontal: spacing[4],
+      minHeight: 44,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    backLinkLabel: {
+      fontSize: fontSize.sm.size,
+      lineHeight: fontSize.sm.lineHeight,
+      color: theme.colors.mutedForeground,
     },
     navBar: {
       flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Replaces the `ActivityIndicator` spinner on task detail initial load with a `TaskDetailSkeleton` (consistent with boards and today screens)
- Adds a retry button to the task detail error state (alongside the existing "Go back")
- Sanitizes generic error message fallbacks in `task/[id].tsx` and `board/[id].tsx` — no raw API error strings shown to users
- Every data-fetching screen now has: loading skeleton, user-friendly error + retry, and empty state with helpful copy

## Changes
- `src/app/(app)/task/[id].tsx` — `TaskDetailSkeleton` component, retry button, sanitized error message
- `src/app/(app)/board/[id].tsx` — sanitized two generic error fallbacks

## Testing
- Task detail: navigate to a task → skeleton appears during load
- Simulate failure (airplane mode) → "Something went wrong" + "Try again" / "Go back"
- All existing board/today states unaffected

Closes #57

---
This PR was created by Claude Code via /work-all.