### PR TITLE
feat: PostHog analytics — screen views and key actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "expo-status-bar": "~55.0.4",
     "expo-updates": "~55.0.16",
     "expo-web-browser": "~55.0.10",
+    "posthog-react-native": "^4.39.1",
     "react": "19.2.0",
     "react-dom": "^19.2.0",
     "react-native": "0.83.4",
@@ -84,7 +85,7 @@
       "^expo/src/winter/(.*)$": "<rootDir>/__mocks__/expo-winter.js"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@trustdesign/.*)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|posthog-react-native|@posthog/.*|@trustdesign/.*)"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/src/app/(app)/board/[id].tsx
+++ b/src/app/(app)/board/[id].tsx
@@ -51,6 +51,7 @@ import {
 } from '../../../lib/task-filters'
 import { Avatar } from '../../../components/ui/Avatar'
 import { Card } from '../../../components/ui/Card'
+import { captureEvent } from '../../../lib/analytics'
 import { EntitlementGate } from '../../../components/EntitlementGate'
 
 const ALL_BOARDS_ID = 'all'
@@ -1457,6 +1458,7 @@ function BoardScreenInner() {
       await setCached(['tasks', user.id, id], result)
       setTasks(id, result)
       setFields(id, fields)
+      captureEvent('board_opened', { item_count: result.length })
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       if (message.includes('401') || message.toLowerCase().includes('expired')) {

--- a/src/app/(app)/paywall/index.tsx
+++ b/src/app/(app)/paywall/index.tsx
@@ -19,6 +19,7 @@ import {
   restorePurchases,
   PRO_ENTITLEMENT_ID,
 } from '../../../lib/purchases'
+import { captureEvent } from '../../../lib/analytics'
 
 // ---------------------------------------------------------------------------
 // Feature list
@@ -68,10 +69,12 @@ export default function PaywallScreen() {
 
   const handlePurchase = useCallback(async () => {
     if (state.kind !== 'ready' || !state.pkg) return
+    captureEvent('purchase_started')
     setState({ kind: 'purchasing' })
     try {
       const info = await purchasePackage(state.pkg)
       if (info.entitlements.active[PRO_ENTITLEMENT_ID] != null) {
+        captureEvent('purchase_completed')
         setState({ kind: 'success' })
         // Give the user a moment to see the confirmation before dismissing
         setTimeout(() => {

--- a/src/app/(app)/task/[id].tsx
+++ b/src/app/(app)/task/[id].tsx
@@ -33,6 +33,7 @@ import { updateFieldValue, type FieldMapping, type FieldOption } from '../../../
 import { useTasksStore } from '../../../stores/tasks-store'
 import { useFieldsStore } from '../../../stores/fields-store'
 import { Avatar } from '../../../components/ui/Avatar'
+import { captureEvent } from '../../../lib/analytics'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -651,6 +652,7 @@ export default function TaskDetailScreen() {
       const result = await fetchTaskDetail(pat, id)
       setDetail(result)
       navigation.setOptions({ title: result.title })
+      captureEvent('task_opened', { is_draft: result.isDraft })
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       if (message.includes('401') || message.toLowerCase().includes('expired')) {
@@ -750,6 +752,7 @@ export default function TaskDetailScreen() {
       updateTask(boardId, id, { status: optionName, statusOptionId: optionId })
       // Haptic fires on user action, not after the API resolves
       void Haptics.selectionAsync()
+      captureEvent('task_status_changed')
 
       // Fire API in background — do NOT await here so EditFieldModal closes immediately
       void (async () => {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -12,12 +12,15 @@ import { useEntitlementCheck } from '../hooks/useEntitlementCheck'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { initPurchases } from '../lib/purchases'
 import { initSentry } from '../lib/sentry'
+import { initAnalytics } from '../lib/analytics'
+import { useScreenTracking } from '../hooks/useScreenTracking'
 
 SplashScreen.preventAutoHideAsync()
 
 // Initialise native SDKs as early as possible (requires dev build).
 initSentry()
 initPurchases()
+initAnalytics()
 
 function RootLayoutNav() {
   const { user, isLoading } = useAuthStore()
@@ -25,6 +28,7 @@ function RootLayoutNav() {
   const router = useRouter()
   useOTAUpdates()
   useEntitlementCheck()
+  useScreenTracking()
 
   useEffect(() => {
     if (isLoading) return

--- a/src/hooks/useScreenTracking.ts
+++ b/src/hooks/useScreenTracking.ts
@@ -1,0 +1,14 @@
+import { usePathname } from 'expo-router'
+import { useEffect } from 'react'
+import { captureScreen } from '../lib/analytics'
+
+/**
+ * Automatically tracks screen views whenever the Expo Router path changes.
+ * Mount once in RootLayoutNav.
+ */
+export function useScreenTracking(): void {
+  const pathname = usePathname()
+  useEffect(() => {
+    captureScreen(pathname)
+  }, [pathname])
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,43 @@
+import PostHog from 'posthog-react-native'
+
+const apiKey = process.env.EXPO_PUBLIC_POSTHOG_API_KEY
+
+let client: PostHog | null = null
+
+/**
+ * Initialise PostHog. Call once at app startup (after Sentry).
+ * No-ops in dev or when the API key is not configured.
+ */
+export function initAnalytics(): void {
+  if (__DEV__ || !apiKey) return
+  client = new PostHog(apiKey, { host: 'https://us.i.posthog.com' })
+}
+
+/**
+ * Track a screen view. Called automatically by useScreenTracking.
+ * Path is the Expo Router pathname — no user identifiers are included.
+ */
+export function captureScreen(path: string): void {
+  if (!client) return
+  client.screen(path, { path })
+}
+
+/** Tracked event names — kept in one place to avoid typos. */
+export type AnalyticsEvent =
+  | 'board_opened'
+  | 'task_opened'
+  | 'task_status_changed'
+  | 'purchase_started'
+  | 'purchase_completed'
+
+/**
+ * Track a discrete user action.
+ * Props must NOT contain PII (no names, emails, or GitHub usernames).
+ */
+export function captureEvent(
+  event: AnalyticsEvent,
+  props?: Record<string, string | number | boolean>
+): void {
+  if (!client) return
+  client.capture(event, props)
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -10,7 +10,12 @@ let client: PostHog | null = null
  */
 export function initAnalytics(): void {
   if (__DEV__ || !apiKey) return
-  client = new PostHog(apiKey, { host: 'https://us.i.posthog.com' })
+  try {
+    client = new PostHog(apiKey, { host: 'https://us.i.posthog.com' })
+  } catch {
+    // Defensive: any unexpected SDK init failure must not crash the app
+    // before error boundaries are mounted.
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- New `src/lib/analytics.ts` — PostHog singleton initialised at startup, no-ops in dev or without `EXPO_PUBLIC_POSTHOG_API_KEY`
- New `src/hooks/useScreenTracking.ts` — automatically tracks screen views via Expo Router `usePathname()`
- Tracks 5 key events: `board_opened`, `task_opened`, `task_status_changed`, `purchase_started`, `purchase_completed`
- No PII — props are only non-identifying values (item counts, boolean flags)
- PostHog added to Jest `transformIgnorePatterns` so tests aren't broken

## Changes
- `src/lib/analytics.ts` — new analytics singleton
- `src/hooks/useScreenTracking.ts` — new screen-view hook
- `src/app/_layout.tsx` — init + mount tracking hook
- `src/app/(app)/board/[id].tsx` — board_opened event
- `src/app/(app)/task/[id].tsx` — task_opened + task_status_changed events
- `src/app/(app)/paywall/index.tsx` — purchase_started + purchase_completed events
- `package.json` — transformIgnorePatterns updated
- `.env.example` — EXPO_PUBLIC_POSTHOG_API_KEY documented

## Testing
- Without API key: all events silently no-op (guarded by `!client`)
- With API key in non-dev: events fire on board/task open and status change
- Purchase events: purchase_started fires on buy tap, purchase_completed on entitlement activation

Closes #63

---
This PR was created by Claude Code via /work-all.