### PR TITLE
feat: accessibility audit — VoiceOver labels and touch targets

### DIFF
--- a/src/app/(app)/(tabs)/account.tsx
+++ b/src/app/(app)/(tabs)/account.tsx
@@ -29,17 +29,17 @@ export default function AccountScreen() {
         <Text style={s.email}>{user?.email ?? ''}</Text>
       </View>
       <View style={s.menu}>
-        <Pressable style={s.menuItem} onPress={() => router.push('/(app)/profile')} accessibilityRole="button">
+        <Pressable style={s.menuItem} onPress={() => router.push('/(app)/profile')} accessibilityRole="button" accessibilityLabel="Edit profile">
           <Text style={s.menuItemText}>Edit profile</Text>
           <Text style={s.menuItemChevron}>\u203a</Text>
         </Pressable>
         <Divider />
-        <Pressable style={s.menuItem} onPress={() => router.push('/(app)/settings')} accessibilityRole="button">
+        <Pressable style={s.menuItem} onPress={() => router.push('/(app)/settings')} accessibilityRole="button" accessibilityLabel="Settings">
           <Text style={s.menuItemText}>Settings</Text>
           <Text style={s.menuItemChevron}>\u203a</Text>
         </Pressable>
         <Divider />
-        <Pressable style={s.menuItem} onPress={handleSignOut} accessibilityRole="button">
+        <Pressable style={s.menuItem} onPress={handleSignOut} accessibilityRole="button" accessibilityLabel="Sign out">
           <Text style={[s.menuItemText, s.signOut]}>Sign out</Text>
         </Pressable>
       </View>

--- a/src/app/(app)/settings/index.tsx
+++ b/src/app/(app)/settings/index.tsx
@@ -104,12 +104,14 @@ export default function SettingsScreen() {
             value={notificationsEnabled}
             onValueChange={toggleNotifications}
             trackColor={{ true: theme.colors.primary }}
+            accessibilityLabel="Push notifications"
           />
         </View>
         <Pressable
           style={s.row}
           onPress={cycleColorScheme}
           accessibilityRole="button"
+          accessibilityLabel="Appearance"
           accessibilityHint="Cycles between system, light, and dark appearance"
         >
           <Text style={s.rowLabel}>Appearance</Text>
@@ -173,6 +175,7 @@ export default function SettingsScreen() {
             )
           }
           accessibilityRole="button"
+          accessibilityLabel="Delete account"
         >
           <Text style={[s.rowLabel, s.danger]}>Delete account</Text>
         </Pressable>

--- a/src/app/(app)/settings/index.tsx
+++ b/src/app/(app)/settings/index.tsx
@@ -112,6 +112,7 @@ export default function SettingsScreen() {
           onPress={cycleColorScheme}
           accessibilityRole="button"
           accessibilityLabel="Appearance"
+          accessibilityValue={{ text: SCHEME_LABELS[colorScheme] }}
           accessibilityHint="Cycles between system, light, and dark appearance"
         >
           <Text style={s.rowLabel}>Appearance</Text>

--- a/src/app/onboarding/index.tsx
+++ b/src/app/onboarding/index.tsx
@@ -72,7 +72,12 @@ export default function OnboardingScreen() {
 
   return (
     <View style={s.container}>
-      <Pressable style={[s.skipButton, { top: insets.top + 16 }]} onPress={handleSkip}>
+      <Pressable
+        style={[s.skipButton, { top: insets.top + 16 }]}
+        onPress={handleSkip}
+        accessibilityRole="button"
+        accessibilityLabel="Skip onboarding"
+      >
         <Text style={s.skipText}>Skip</Text>
       </Pressable>
 
@@ -94,7 +99,12 @@ export default function OnboardingScreen() {
           ))}
         </View>
 
-        <Pressable style={s.button} onPress={handleNext}>
+        <Pressable
+          style={s.button}
+          onPress={handleNext}
+          accessibilityRole="button"
+          accessibilityLabel={currentIndex === STEPS.length - 1 ? 'Get started' : 'Next'}
+        >
           <Text style={s.buttonText}>
             {currentIndex === STEPS.length - 1 ? 'Get started' : 'Next'}
           </Text>
@@ -114,6 +124,8 @@ function styles(theme: ReturnType<typeof useTheme>['theme']) {
       position: 'absolute',
       right: 24,
       zIndex: 1,
+      minHeight: 44,
+      justifyContent: 'center',
     },
     skipText: {
       fontSize: 16,


### PR DESCRIPTION
## Summary
- Add missing `accessibilityLabel` to all interactive elements across account, settings, and onboarding screens
- Add `accessibilityRole=\"button\"` to Skip and Next/Get started Pressables in onboarding
- Fix Skip button touch target: `minHeight: 44` added to meet iOS HIG 44pt minimum

## Changes
- `account.tsx` — `accessibilityLabel` added to Edit profile, Settings, Sign out Pressables
- `onboarding/index.tsx` — `accessibilityRole` + `accessibilityLabel` on Skip and Next buttons; `minHeight: 44` on Skip
- `settings/index.tsx` — `accessibilityLabel` on Push notifications Switch, Appearance button, Delete account button

Screens already passing before this PR:
- `sign-in.tsx` — uses `Button` component (fully annotated)
- `paywall/index.tsx` — all Pressables already had `accessibilityRole` + `accessibilityLabel`
- `Button.tsx` — `accessibilityRole`, `accessibilityState`, min heights ✅
- `TextInput.tsx` — `accessibilityLabel`, `accessibilityLiveRegion` ✅

## Testing
- [ ] Enable VoiceOver on device, navigate each screen — all interactive elements announced correctly
- [ ] Verify Skip button is easily tappable in top-right corner (min 44pt target)
- [ ] Confirm Appearance and Delete account read their labels correctly before activating

Closes #67

---
This PR was created by Claude Code via /work-all.